### PR TITLE
Add orbit-db test utils

### DIFF
--- a/test/utils/config.js
+++ b/test/utils/config.js
@@ -1,0 +1,75 @@
+module.exports = {
+  timeout: 30000,
+  dbname: 'orbit-db-tests',
+  defaultIpfsConfig: {
+    start: true,
+    EXPERIMENTAL: {
+      pubsub: true
+    },
+    config: {
+      Addresses: {
+        API: '/ip4/127.0.0.1/tcp/0',
+        Swarm: ['/ip4/0.0.0.0/tcp/0'],
+        Gateway: '/ip4/0.0.0.0/tcp/0'
+      },
+      Bootstrap: [],
+      Discovery: {
+        MDNS: {
+          Enabled: true,
+          Interval: 1
+        },
+        webRTCStar: {
+          Enabled: false
+        }
+      },
+    }
+  },
+  daemon1: {
+    repo: './ipfs/orbitdb/tests/daemon1',
+    start: true,
+    EXPERIMENTAL: {
+      pubsub: true
+    },
+    config: {
+      Addresses: {
+        API: '/ip4/127.0.0.1/tcp/0',
+        Swarm: ['/ip4/0.0.0.0/tcp/0'],
+        Gateway: '/ip4/0.0.0.0/tcp/0'
+      },
+      Bootstrap: [],
+      Discovery: {
+        MDNS: {
+          Enabled: true,
+          Interval: 1
+        },
+        webRTCStar: {
+          Enabled: false
+        }
+      },
+    },
+  },
+  daemon2: {
+    repo: './ipfs/orbitdb/tests/daemon2',
+    start: true,
+    EXPERIMENTAL: {
+      pubsub: true
+    },
+    config: {
+      Addresses: {
+        API: '/ip4/127.0.0.1/tcp/0',
+        Swarm: ['/ip4/0.0.0.0/tcp/0'],
+        Gateway: '/ip4/0.0.0.0/tcp/0'
+      },
+      Bootstrap: [],
+      Discovery: {
+        MDNS: {
+          Enabled: true,
+          Interval: 1
+        },
+        webRTCStar: {
+          Enabled: false
+        }
+      },
+    },
+  },
+}

--- a/test/utils/connect-peers.js
+++ b/test/utils/connect-peers.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const connectIpfsNodes = async (ipfs1, ipfs2) => {
+  const id1 = await ipfs1.id()
+  const id2 = await ipfs2.id()
+  await ipfs1.swarm.connect(id2.addresses[0])
+  await ipfs2.swarm.connect(id1.addresses[0])
+}
+
+module.exports = connectIpfsNodes

--- a/test/utils/custom-test-keystore.js
+++ b/test/utils/custom-test-keystore.js
@@ -1,0 +1,53 @@
+const EC = require('elliptic').ec
+const ec = new EC('secp256k1')
+
+/**
+ * A custom keystore example
+ */
+class CustomTestKeystore {
+  constructor(signer) {
+    this.createKey();
+  }
+
+  createKey() {
+    const key = ec.genKeyPair()
+    this.key = ec.keyPair({
+      pub:  key.getPublic('hex'),
+      priv: key.getPrivate('hex'),
+      privEnc: 'hex',
+      pubEnc: 'hex',
+    })
+
+    return this.key
+  }
+
+  getKey() {
+    return this.key
+  }
+
+  // TODO: check if this is really in use
+  generateKey() {
+    return Promise.resolve(this.createKey())
+  }
+
+  importPublicKey(key) {
+    return Promise.resolve(ec.keyFromPublic(key, 'hex'))
+  }
+
+  importPrivateKey(key) {
+    return Promise.resolve(ec.keyFromPrivate(key, 'hex'))
+  }
+
+  sign(key, data) {
+    const sig = ec.sign(data, key)
+    return Promise.resolve(sig.toDER('hex'))
+  }
+
+  verify(signature, key, data) {
+    let res = false
+    res = ec.verify(data, signature, key)
+    return Promise.resolve(res)
+  }
+}
+
+module.exports = new CustomTestKeystore()

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -1,0 +1,8 @@
+exports.config = require('./config.js')
+exports.testAPIs = require('./test-apis')
+exports.startIpfs = require('./start-ipfs')
+exports.stopIpfs = require('./stop-ipfs')
+exports.waitForPeers = require('./wait-for-peers')
+exports.connectPeers = require('./connect-peers')
+exports.MemStore = require('./mem-store')
+exports.CustomTestKeystore = require('./custom-test-keystore')

--- a/test/utils/mem-store.js
+++ b/test/utils/mem-store.js
@@ -1,0 +1,95 @@
+'use strict'
+
+const multihashing = require('multihashing-async')
+const mh = require('multihashes')
+
+const defaultHashAlg = 'sha2-256'
+
+// 'use strict'
+
+// const ImmutableDB = require('./immutabledb-interface')
+
+const defaultFormat = { format: 'dag-cbor', hashAlg: 'sha2-256' }
+
+/* ImmutableDB using IPLD (through IPFS) */
+class IPLDStore {
+  constructor (ipfs) {
+    // super()
+    this._ipfs = ipfs
+  }
+
+  async put (value) {
+    const cid = await this._ipfs.dag.put(value, defaultFormat)
+    return cid.toBaseEncodedString()
+  }
+
+  async get (key) {
+    const result = await this._ipfs.dag.get(key)
+    return result.value
+  }
+}
+
+const createMultihash = (data, hashAlg) => {
+  return new Promise((resolve, reject) => {
+    multihashing(data, hashAlg || defaultHashAlg, (err, multihash) => {
+      if (err)
+        return reject(err)
+
+      resolve(mh.toB58String(multihash))
+    })
+  })
+}
+
+// const LRU = require('lru')
+// const ImmutableDB = require('./immutabledb-interface')
+// const createMultihash = require('./create-multihash')
+
+/* Memory store using an LRU cache */
+class MemStore {
+  constructor () {
+    this._store = {}//new LRU(1000)
+  }
+
+  async put (value) {
+    const data = value//new Buffer(JSON.stringify(value))
+    const hash = await createMultihash(data)
+    // console.log(this._store)
+    // this._store.set(hash, data)
+    if (!this._store) this._store = {}
+    // console.log(this._store)
+    // console.log(hash, data)
+    this._store[hash] = data
+    // return hash
+    return {
+      toJSON: () => {
+        return {
+          data: value,
+          multihash: hash,
+        }
+      }
+    }
+  }
+
+  async get (key) {
+    // const data = this._store.get(key)
+    const data = this._store[key]
+
+    // if (data) {
+    //   const value = JSON.parse(data)
+    //   return value
+    // }
+
+    // return data
+    return {
+      toJSON: () => {
+        return {
+          data: this._store[key],
+          multihash: key,
+        }
+      }
+    }
+  }
+}
+
+
+module.exports = MemStore

--- a/test/utils/start-ipfs.js
+++ b/test/utils/start-ipfs.js
@@ -1,0 +1,43 @@
+'use strict'
+
+const IPFSFactory = require('ipfsd-ctl')
+const testAPIs = require('./test-apis')
+
+/**
+ * Start an IPFS instance
+ * @param  {Object}  config  [IPFS configuration to use]
+ * @return {[Promise<IPFS>]} [IPFS instance]
+ */
+const startIpfs = (type, config = {}) => {
+  return new Promise((resolve, reject) => {
+    if (!testAPIs[type]) {
+      reject(new Error(`Wanted API type ${JSON.stringify(type)} is unknown. Available types: ${Object.keys(testAPIs).join(', ')}`))
+    }
+
+    // If we're starting a process, pass command line arguments to it
+    if (!config.args) {
+      config.args = ['--enable-pubsub-experiment']
+    }
+
+    // Spawn an IPFS daemon (type defined in)
+    IPFSFactory
+      .create(testAPIs[type])
+      .spawn(config, async (err, ipfsd) => {
+        if (err) { 
+          reject(err) 
+        }
+
+        // Monkey patch _peerInfo to the ipfs api/instance
+        // to make js-ipfs-api compatible with js-ipfs
+        // TODO: Get IPFS id via coherent API call (without it being asynchronous)
+        if (!ipfsd.api._peerInfo) {
+          let { id } = await ipfsd.api.id()
+          ipfsd.api._peerInfo = { id: { _idB58String: id } }
+        }
+
+        resolve(ipfsd)
+      })
+  })
+}
+
+module.exports = startIpfs

--- a/test/utils/stop-ipfs.js
+++ b/test/utils/stop-ipfs.js
@@ -1,0 +1,17 @@
+'use strict'
+
+/**
+ * Stop an IPFS or ipfsd-ctl instance
+ * @param  {Object}  config  [IPFS ipfsd-ctl to stop]
+ * @return {None}
+ */
+const stopIpfs = (ipfs) => {
+  return new Promise(async (resolve, reject) => {
+    ipfs.stop((err) => {
+      if (err) { reject(err) }
+      resolve()
+    })
+  })
+}
+
+module.exports = stopIpfs

--- a/test/utils/test-apis.js
+++ b/test/utils/test-apis.js
@@ -1,0 +1,33 @@
+const IPFS = require('ipfs')
+
+/**
+ * IPFS daemons to run the tests with.
+ */
+
+// Available daemon types are defined in:
+// https://github.com/ipfs/js-ipfsd-ctl#ipfsfactory---const-f--ipfsfactorycreateoptions
+let jsIpfs = {
+  'js-ipfs': {
+    type: 'proc', 
+    exec: IPFS,
+  }
+}
+
+const goIpfs = {
+  'go-ipfs': {
+    type: 'go',
+  }
+}
+
+// By default, we run tests against js-ipfs.
+let testAPIs = Object.assign({}, jsIpfs)
+
+// Setting env variable 'TEST=all' will make tests run with js-ipfs and go-ipfs.
+// Setting env variable 'TEST=go' will make tests run with go-ipfs.
+// Eg. 'TEST=go mocha' runs tests with go-ipfs
+if (process.env.TEST === 'all')
+  testAPIs = Object.assign({}, testAPIs, goIpfs)
+else if (process.env.TEST === 'go')
+  testAPIs = Object.assign({}, goIpfs)
+
+module.exports = testAPIs

--- a/test/utils/wait-for-peers.js
+++ b/test/utils/wait-for-peers.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const waitForPeers = (ipfs, peersToWait, topic, callback) => {
+  return new Promise((resolve, reject) => {
+    const i = setInterval(async () => {
+      const peers = await ipfs.pubsub.peers(topic)
+      const hasAllPeers = peersToWait.map((e) => peers.includes(e)).filter((e) => e === false).length === 0
+      if (hasAllPeers) {
+        clearInterval(i)
+        resolve()
+      }
+    }, 500)
+  })
+}
+
+module.exports = waitForPeers


### PR DESCRIPTION
This PR will add test utils from orbitdb and ipfs-log to be used in test.