### PR TITLE
Use object.assign instead of spread syntax to make webpack happy

### DIFF
--- a/src/access-controllers.js
+++ b/src/access-controllers.js
@@ -41,7 +41,7 @@ class AccessControllers {
   static async resolve (orbitdb, manifestAddress, options) {
     const { type, params } = await AccessControllerManifest.resolve(orbitdb._ipfs, manifestAddress)
     const AccessController = getHandlerFor(type)
-    const ac = await AccessController.create(orbitdb, {...options, ...params})
+    const ac = await AccessController.create(orbitdb, Object.assign({}, options, params))
     await ac.load(params.address, params)
     return ac
   }


### PR DESCRIPTION
This PR will change the syntax of merging objects to use Object.assign instead of spread syntax to have better backward support.