### PR TITLE
(WIP) use latest identity provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@babel/runtime": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.5.tgz",
-      "integrity": "sha512-xKnPpXG/pvK1B90JkwwxSGii90rQGKtzcMt2gI5G6+M0REXaq6rOHsGC2ay6/d0Uje7zzvSzjEzfR3ENhFlrfA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.2.0.tgz",
+      "integrity": "sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.12.0"
@@ -54,9 +54,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.12.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.8.tgz",
-      "integrity": "sha512-INamyRZG4rW3lDCUmwVd5Xho/bXvQm/v1yP8V0UN1RuInU7RoWoaO570b+yLX4Ia/0szsx1wa8VzcsVlsvbWLA==",
+      "version": "10.12.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.12.tgz",
+      "integrity": "sha512-Pr+6JRiKkfsFvmU/LK68oBRCQeEg36TyAbPhc2xpez24OOZZCuoIhWGTd39VZy6nGafSbxzGouFPTFD/rR1A0A==",
       "dev": true
     },
     "File": {
@@ -133,9 +133,9 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
-      "integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.1.tgz",
+      "integrity": "sha512-ZoJjft5B+EJBjUyu9C9Hc0OZyPZSSlOF+plzouTrg6UlA8f+e/n8NIgBFG/9tppJtpPWfthHakK7juJdNDODww==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
@@ -252,7 +252,7 @@
     },
     "array-flatten": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "dev": true
     },
@@ -408,12 +408,6 @@
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
       "dev": true
     },
-    "bigi": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/bigi/-/bigi-1.4.2.tgz",
-      "integrity": "sha1-nGZalfiLiwj8Bc/XMfVhhZ1yWCU=",
-      "dev": true
-    },
     "bignumber.js": {
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
@@ -437,9 +431,9 @@
       "dev": true
     },
     "bindings": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.1.tgz",
+      "integrity": "sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew==",
       "dev": true
     },
     "bintrees": {
@@ -447,6 +441,20 @@
       "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
       "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ=",
       "dev": true
+    },
+    "bip32": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bip32/-/bip32-1.0.2.tgz",
+      "integrity": "sha512-kedLYj8yvYzND+EfzeoMSlGiN7ImiRBF/MClJSZPkMfcU+OQO7ZpL5L/Yg+TunebBZIHhunstiQF//KLKSF5rg==",
+      "dev": true,
+      "requires": {
+        "bs58check": "^2.1.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "tiny-secp256k1": "^1.0.0",
+        "typeforce": "^1.11.5",
+        "wif": "^2.0.6"
+      }
     },
     "bip66": {
       "version": "1.1.5",
@@ -464,23 +472,23 @@
       "dev": true
     },
     "bitcoinjs-lib": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-3.3.2.tgz",
-      "integrity": "sha512-l5qqvbaK8wwtANPf6oEffykycg4383XgEYdia1rI7/JpGf1jfRWlOUCvx5TiTZS7kyIvY4j/UhIQ2urLsvGkzw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-4.0.2.tgz",
+      "integrity": "sha512-Y6AW91WPDoDQQLy4FejVoH4NvENqvMy+Q/8mnakEzckG1NXiLo0VgnEZyuvZb6lkhE2+YxzTCgpqzbnerOSpEg==",
       "dev": true,
       "requires": {
         "bech32": "^1.1.2",
-        "bigi": "^1.4.0",
+        "bip32": "^1.0.0",
         "bip66": "^1.1.0",
-        "bitcoin-ops": "^1.3.0",
+        "bitcoin-ops": "^1.4.0",
         "bs58check": "^2.0.0",
         "create-hash": "^1.1.0",
         "create-hmac": "^1.1.3",
-        "ecurve": "^1.0.0",
         "merkle-lib": "^2.0.10",
         "pushdata-bitcoin": "^1.0.1",
         "randombytes": "^2.0.1",
-        "safe-buffer": "^5.0.1",
+        "safe-buffer": "^5.1.1",
+        "tiny-secp256k1": "^1.0.0",
         "typeforce": "^1.11.3",
         "varuint-bitcoin": "^1.0.4",
         "wif": "^2.0.1"
@@ -565,18 +573,18 @@
       }
     },
     "boom": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.2.tgz",
-      "integrity": "sha512-IFUbOa8PS7xqmhIjpeStwT3d09hGkNYQ6aj2iELSTxcVs2u0aKn1NzhkdUQSzsRg1FVkj3uit3I6mXQCBixw+A==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-7.3.0.tgz",
+      "integrity": "sha512-Swpoyi2t5+GhOEGw8rEsKvTxFLIDiiKoUc2gsoV6Lyr43LHBIzch3k2MvYUs8RTROrIkVJ3Al0TkaOGjnb+B6A==",
       "dev": true,
       "requires": {
         "hoek": "6.x.x"
       },
       "dependencies": {
         "hoek": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.0.3.tgz",
-          "integrity": "sha512-TU6RyZ/XaQCTWRLrdqZZtZqwxUVr6PDMfi6MlWNURZ7A6czanQqX4pFE1mdOUQR9FdPCsZ0UzL8jI/izZ+eBSQ==",
+          "version": "6.1.2",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.2.tgz",
+          "integrity": "sha512-6qhh/wahGYZHFSFw12tBbJw5fsAhhwrrG/y3Cs0YMTv2WzMnL0oLPnQJjv1QJvEfylRSOFuP+xCu+tdx0tD16Q==",
           "dev": true
         }
       }
@@ -612,6 +620,12 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true
         },
         "is-fullwidth-code-point": {
@@ -920,9 +934,9 @@
       "dev": true
     },
     "camelcase": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+      "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
       "dev": true
     },
     "capture-stack-trace": {
@@ -1046,15 +1060,35 @@
       }
     },
     "cids": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/cids/-/cids-0.5.5.tgz",
-      "integrity": "sha512-oU8v+N8rViFBcj5KcsXK0gbPiMFHpP/VGlGoWQXZguJsA8ZW0X47fKt0ZPIu03U8CL1Fy+R56tO79urY6MLaSw==",
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/cids/-/cids-0.5.7.tgz",
+      "integrity": "sha512-SlAz4p8XMEW3mhwiYbzfjn+5+Y//+kIuHqzRUytK0a3uGBnsjJb76xHliehv0HcVMCjRKv2vZnPTwd4QX+IcMA==",
       "dev": true,
       "requires": {
         "class-is": "^1.1.0",
-        "multibase": "~0.5.0",
+        "multibase": "~0.6.0",
         "multicodec": "~0.2.7",
         "multihashes": "~0.4.14"
+      },
+      "dependencies": {
+        "base-x": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
+          "integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "multibase": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.0.tgz",
+          "integrity": "sha512-R9bNLQhbD7MsitPm1NeY7w9sDgu6d7cuj25snAWH7k5PSNPSwIQQBpcpj8jx1W96dLbdigZqmUWOdQRMnAmgjA==",
+          "dev": true,
+          "requires": {
+            "base-x": "3.0.4"
+          }
+        }
       }
     },
     "cipher-base": {
@@ -1521,13 +1555,10 @@
       }
     },
     "decamelize": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
-      "integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
-      "dev": true,
-      "requires": {
-        "xregexp": "4.0.0"
-      }
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -1794,7 +1825,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
@@ -1887,16 +1918,6 @@
         "safer-buffer": "^2.1.0"
       }
     },
-    "ecurve": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/ecurve/-/ecurve-1.0.6.tgz",
-      "integrity": "sha512-/BzEjNfiSuB7jIWKcS/z8FK9jNjmEWvUV2YZ4RLSmcDtP7Lq0m6FvDuSnJpBlDpGRpfRQeTLGLBI8H+kEv0r+w==",
-      "dev": true,
-      "requires": {
-        "bigi": "^1.1.0",
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -1947,9 +1968,9 @@
       }
     },
     "engine.io": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.1.tgz",
-      "integrity": "sha512-+VlKzHzMhaU+GsCIg4AoXF1UdDFjHHwMmMKqMJNDNLlUlejz58FCy4LBqB2YVJskHGYl06BatYWKP2TVdVXE5w==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.3.2.tgz",
+      "integrity": "sha512-AsaA9KG7cWPXWHp5FvHdDWY3AMWeZ8x+2pUVLcn71qE5AtAzgGbxuclOytygskw8XGmiQafTmnI9Bix3uihu2w==",
       "dev": true,
       "requires": {
         "accepts": "~1.3.4",
@@ -1957,7 +1978,7 @@
         "cookie": "0.3.1",
         "debug": "~3.1.0",
         "engine.io-parser": "~2.1.0",
-        "ws": "~3.3.1"
+        "ws": "~6.1.0"
       },
       "dependencies": {
         "debug": {
@@ -1975,29 +1996,21 @@
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
-        "ultron": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-          "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
-          "dev": true
-        },
         "ws": {
-          "version": "3.3.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-          "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+          "version": "6.1.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.2.tgz",
+          "integrity": "sha512-rfUqzvz0WxmSXtJpPMX2EeASXabOrSMk1ruMOV3JBTBjo4ac2lDjGGsbQSyxj8Odhw5fBib8ZKEjDNvgouNKYw==",
           "dev": true,
           "requires": {
-            "async-limiter": "~1.0.0",
-            "safe-buffer": "~5.1.0",
-            "ultron": "~1.1.0"
+            "async-limiter": "~1.0.0"
           }
         }
       }
     },
     "engine.io-client": {
-      "version": "3.2.1",
-      "resolved": "http://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
-      "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.3.1.tgz",
+      "integrity": "sha512-q66JBFuQcy7CSlfAz9L3jH+v7DTT3i6ZEadYcVj2pOs8/0uJHLxKX3WBkGTvULJMdz0tUCyJag0aKT/dpXL9BQ==",
       "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
@@ -2008,7 +2021,7 @@
         "indexof": "0.0.1",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "ws": "~3.3.1",
+        "ws": "~6.1.0",
         "xmlhttprequest-ssl": "~1.5.4",
         "yeast": "0.1.2"
       },
@@ -2028,21 +2041,13 @@
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
-        "ultron": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-          "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
-          "dev": true
-        },
         "ws": {
-          "version": "3.3.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-          "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+          "version": "6.1.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.2.tgz",
+          "integrity": "sha512-rfUqzvz0WxmSXtJpPMX2EeASXabOrSMk1ruMOV3JBTBjo4ac2lDjGGsbQSyxj8Odhw5fBib8ZKEjDNvgouNKYw==",
           "dev": true,
           "requires": {
-            "async-limiter": "~1.0.0",
-            "safe-buffer": "~5.1.0",
-            "ultron": "~1.1.0"
+            "async-limiter": "~1.0.0"
           }
         }
       }
@@ -2231,9 +2236,9 @@
       }
     },
     "ethereumjs-common": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-0.6.0.tgz",
-      "integrity": "sha512-KN1BScZ6bMUIBMP7a2hNJYhpcY/TvXxU/9B0t9xOyytheIWOaJynVLwStma/oHICIlStSmfbwLvP0CPbek+IXQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-0.6.1.tgz",
+      "integrity": "sha512-4jOrfDu9qOBTTGGb3zrfT1tE1Hyc6a8LJpEk0Vk9AYlLkBY7crjVICyJpRvjNI+KLDMpMITMw3eWVZOLMtZdhw==",
       "dev": true
     },
     "ethereumjs-tx": {
@@ -2279,9 +2284,9 @@
       }
     },
     "ethers": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.12.tgz",
-      "integrity": "sha512-ozp0RAqpYZAu/CvhqWKBo5KqQOT5j55+3vrnQfkHaQDqjq374fy/lfLzTH655SeHFh/RTZda5L742Nn1Q2vImQ==",
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.18.tgz",
+      "integrity": "sha512-yz4CTgDjPeIrYEarT4lNE/7A7t0XWj5xiOu+8RmHj26S4py+6iW6NlzmukH1K670QsxFmFdp9FiukNiD0SO76w==",
       "dev": true,
       "requires": {
         "@types/node": "^10.3.2",
@@ -2514,9 +2519,9 @@
       "dev": true
     },
     "file-type": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-10.4.0.tgz",
-      "integrity": "sha512-/Ha0T7TRFOFKgj36icy46h93By2tTwHirW9qeNLslo5NYmd7BbITVv2tkcuohmZWsNLqg9/dKNKwRXF3OVgVdA==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-10.6.0.tgz",
+      "integrity": "sha512-GNOg09GC+rZzxetGZFoL7QOnWXRqvWuEdKURIJlr0d6MW107Iwy6voG1PPOrm5meG6ls59WkBmBMAZdVSVajRQ==",
       "dev": true
     },
     "filereader": {
@@ -2575,35 +2580,6 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
           "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-          "dev": true
-        }
-      }
-    },
-    "find-process": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/find-process/-/find-process-1.2.1.tgz",
-      "integrity": "sha512-z4RXYStNAcoi4+smpKbzJXbMT8DdvwqTE7wL7DWZMD0SkTRfQ49z9S7YaK24kuRseKr23YSZlnyL/TaJZtgM1g==",
-      "dev": true,
-      "requires": {
-        "chalk": "^2.0.1",
-        "commander": "^2.11.0",
-        "debug": "^2.6.8",
-        "lodash": "^4.17.11"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
       }
@@ -2732,15 +2708,6 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true
     },
-    "fs-ext": {
-      "version": "github:baudehlo/node-fs-ext#2ba366d9fc67ef3ab165e239068924b276ecf249",
-      "from": "github:baudehlo/node-fs-ext#master",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "nan": "^2.10.0"
-      }
-    },
     "fs-extra": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
@@ -2814,12 +2781,6198 @@
       "dev": true
     },
     "ganache-cli": {
-      "version": "6.1.8",
-      "resolved": "https://registry.npmjs.org/ganache-cli/-/ganache-cli-6.1.8.tgz",
-      "integrity": "sha512-yXzteu4SIgUL31mnpm9j+x6dpHUw0p/nsRVkcySKq0w+1vDxH9jMErP1QhZAJuTVE6ni4nfvGSNkaQx5cD3jfg==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ganache-cli/-/ganache-cli-6.2.3.tgz",
+      "integrity": "sha512-+FYzINouw+yHHG6bT8m6O5xCw5NP6rpSL2keChKlcwgRRFz8SrZS6Q26iJ7ixBp6bk+UMMua8IPZgNFizbdZlQ==",
       "dev": true,
       "requires": {
-        "source-map-support": "^0.5.3"
+        "bn.js": "4.11.8",
+        "ganache-core": "^2.3.1",
+        "source-map-support": "^0.5.3",
+        "yargs": "^11.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "dev": true
+        },
+        "buffer-from": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+          "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+          "dev": true
+        },
+        "execa": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "ganache-core": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/ganache-core/-/ganache-core-2.3.1.tgz",
+          "integrity": "sha512-I4t4P+LYUZRnGbxDseqSa5vIJ8C5e35vw5Fr7f2iMMN6jmO5TVjWWgNib60G2iL+XTbYUFmou040hHxrTaNtnA==",
+          "dev": true,
+          "requires": {
+            "abstract-leveldown": "3.0.0",
+            "async": "2.6.1",
+            "bip39": "2.5.0",
+            "bn.js": "4.11.8",
+            "cachedown": "1.0.0",
+            "clone": "2.1.2",
+            "debug": "3.1.0",
+            "encoding-down": "5.0.4",
+            "eth-sig-util": "2.0.2",
+            "ethereumjs-abi": "0.6.5",
+            "ethereumjs-account": "2.0.5",
+            "ethereumjs-block": "1.2.2",
+            "ethereumjs-tx": "1.3.7",
+            "ethereumjs-util": "5.2.0",
+            "ethereumjs-vm": "2.4.0",
+            "ethereumjs-wallet": "0.6.2",
+            "heap": "0.2.6",
+            "level-sublevel": "6.6.4",
+            "levelup": "3.1.1",
+            "lodash": "4.17.10",
+            "merkle-patricia-tree": "2.3.1",
+            "seedrandom": "2.4.4",
+            "tmp": "0.0.33",
+            "web3": "1.0.0-beta.35",
+            "web3-provider-engine": "14.1.0",
+            "websocket": "1.0.26"
+          },
+          "dependencies": {
+            "abstract-leveldown": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-3.0.0.tgz",
+              "integrity": "sha512-KUWx9UWGQD12zsmLNj64/pndaz4iJh/Pj7nopgkfDG6RlCcbMZvT6+9l7dchK4idog2Is8VdC/PvNbFuFmalIQ==",
+              "dev": true,
+              "requires": {
+                "xtend": "~4.0.0"
+              }
+            },
+            "accepts": {
+              "version": "1.3.5",
+              "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+              "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+              "dev": true,
+              "requires": {
+                "mime-types": "~2.1.18",
+                "negotiator": "0.6.1"
+              }
+            },
+            "aes-js": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
+              "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ==",
+              "dev": true,
+              "optional": true
+            },
+            "ajv": {
+              "version": "6.5.5",
+              "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
+              "integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
+              "dev": true,
+              "requires": {
+                "fast-deep-equal": "^2.0.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+              }
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+              "dev": true
+            },
+            "ansi-styles": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+              "dev": true
+            },
+            "any-promise": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+              "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
+              "dev": true
+            },
+            "array-flatten": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+              "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+              "dev": true
+            },
+            "asn1": {
+              "version": "0.2.4",
+              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+              "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+              "dev": true,
+              "requires": {
+                "safer-buffer": "~2.1.0"
+              }
+            },
+            "asn1.js": {
+              "version": "4.10.1",
+              "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+              "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+              "dev": true,
+              "requires": {
+                "bn.js": "^4.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0"
+              }
+            },
+            "assert-plus": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "dev": true
+            },
+            "async": {
+              "version": "2.6.1",
+              "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+              "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+              "dev": true,
+              "requires": {
+                "lodash": "^4.17.10"
+              }
+            },
+            "async-eventemitter": {
+              "version": "0.2.4",
+              "resolved": "https://registry.npmjs.org/async-eventemitter/-/async-eventemitter-0.2.4.tgz",
+              "integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
+              "dev": true,
+              "requires": {
+                "async": "^2.4.0"
+              }
+            },
+            "async-limiter": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+              "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+              "dev": true
+            },
+            "asynckit": {
+              "version": "0.4.0",
+              "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+              "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+              "dev": true
+            },
+            "aws-sign2": {
+              "version": "0.7.0",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+              "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+              "dev": true
+            },
+            "aws4": {
+              "version": "1.8.0",
+              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+              "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+              "dev": true
+            },
+            "babel-code-frame": {
+              "version": "6.26.0",
+              "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+              "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+              "dev": true,
+              "requires": {
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
+              }
+            },
+            "babel-core": {
+              "version": "6.26.3",
+              "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+              "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+              "dev": true,
+              "requires": {
+                "babel-code-frame": "^6.26.0",
+                "babel-generator": "^6.26.0",
+                "babel-helpers": "^6.24.1",
+                "babel-messages": "^6.23.0",
+                "babel-register": "^6.26.0",
+                "babel-runtime": "^6.26.0",
+                "babel-template": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "convert-source-map": "^1.5.1",
+                "debug": "^2.6.9",
+                "json5": "^0.5.1",
+                "lodash": "^4.17.4",
+                "minimatch": "^3.0.4",
+                "path-is-absolute": "^1.0.1",
+                "private": "^0.1.8",
+                "slash": "^1.0.0",
+                "source-map": "^0.5.7"
+              },
+              "dependencies": {
+                "debug": {
+                  "version": "2.6.9",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                  "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                  "dev": true,
+                  "requires": {
+                    "ms": "2.0.0"
+                  }
+                }
+              }
+            },
+            "babel-generator": {
+              "version": "6.26.1",
+              "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+              "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+              "dev": true,
+              "requires": {
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "detect-indent": "^4.0.0",
+                "jsesc": "^1.3.0",
+                "lodash": "^4.17.4",
+                "source-map": "^0.5.7",
+                "trim-right": "^1.0.1"
+              },
+              "dependencies": {
+                "jsesc": {
+                  "version": "1.3.0",
+                  "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+                  "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+                  "dev": true
+                }
+              }
+            },
+            "babel-helper-builder-binary-assignment-operator-visitor": {
+              "version": "6.24.1",
+              "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+              "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+              "dev": true,
+              "requires": {
+                "babel-helper-explode-assignable-expression": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
+              }
+            },
+            "babel-helper-call-delegate": {
+              "version": "6.24.1",
+              "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+              "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+              "dev": true,
+              "requires": {
+                "babel-helper-hoist-variables": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
+              }
+            },
+            "babel-helper-define-map": {
+              "version": "6.26.0",
+              "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
+              "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+              "dev": true,
+              "requires": {
+                "babel-helper-function-name": "^6.24.1",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "lodash": "^4.17.4"
+              }
+            },
+            "babel-helper-explode-assignable-expression": {
+              "version": "6.24.1",
+              "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+              "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+              "dev": true,
+              "requires": {
+                "babel-runtime": "^6.22.0",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
+              }
+            },
+            "babel-helper-function-name": {
+              "version": "6.24.1",
+              "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+              "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+              "dev": true,
+              "requires": {
+                "babel-helper-get-function-arity": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
+              }
+            },
+            "babel-helper-get-function-arity": {
+              "version": "6.24.1",
+              "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+              "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+              "dev": true,
+              "requires": {
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
+              }
+            },
+            "babel-helper-hoist-variables": {
+              "version": "6.24.1",
+              "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+              "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+              "dev": true,
+              "requires": {
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
+              }
+            },
+            "babel-helper-optimise-call-expression": {
+              "version": "6.24.1",
+              "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+              "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+              "dev": true,
+              "requires": {
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
+              }
+            },
+            "babel-helper-regex": {
+              "version": "6.26.0",
+              "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
+              "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+              "dev": true,
+              "requires": {
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "lodash": "^4.17.4"
+              }
+            },
+            "babel-helper-remap-async-to-generator": {
+              "version": "6.24.1",
+              "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+              "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+              "dev": true,
+              "requires": {
+                "babel-helper-function-name": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
+              }
+            },
+            "babel-helper-replace-supers": {
+              "version": "6.24.1",
+              "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+              "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+              "dev": true,
+              "requires": {
+                "babel-helper-optimise-call-expression": "^6.24.1",
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
+              }
+            },
+            "babel-helpers": {
+              "version": "6.24.1",
+              "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+              "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+              "dev": true,
+              "requires": {
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
+              }
+            },
+            "babel-messages": {
+              "version": "6.23.0",
+              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+              "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+              "dev": true,
+              "requires": {
+                "babel-runtime": "^6.22.0"
+              }
+            },
+            "babel-plugin-check-es2015-constants": {
+              "version": "6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+              "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+              "dev": true,
+              "requires": {
+                "babel-runtime": "^6.22.0"
+              }
+            },
+            "babel-plugin-syntax-async-functions": {
+              "version": "6.13.0",
+              "resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+              "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+              "dev": true
+            },
+            "babel-plugin-syntax-exponentiation-operator": {
+              "version": "6.13.0",
+              "resolved": "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+              "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+              "dev": true
+            },
+            "babel-plugin-syntax-trailing-function-commas": {
+              "version": "6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+              "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+              "dev": true
+            },
+            "babel-plugin-transform-async-to-generator": {
+              "version": "6.24.1",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+              "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+              "dev": true,
+              "requires": {
+                "babel-helper-remap-async-to-generator": "^6.24.1",
+                "babel-plugin-syntax-async-functions": "^6.8.0",
+                "babel-runtime": "^6.22.0"
+              }
+            },
+            "babel-plugin-transform-es2015-arrow-functions": {
+              "version": "6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+              "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+              "dev": true,
+              "requires": {
+                "babel-runtime": "^6.22.0"
+              }
+            },
+            "babel-plugin-transform-es2015-block-scoped-functions": {
+              "version": "6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+              "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+              "dev": true,
+              "requires": {
+                "babel-runtime": "^6.22.0"
+              }
+            },
+            "babel-plugin-transform-es2015-block-scoping": {
+              "version": "6.26.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+              "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+              "dev": true,
+              "requires": {
+                "babel-runtime": "^6.26.0",
+                "babel-template": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "lodash": "^4.17.4"
+              }
+            },
+            "babel-plugin-transform-es2015-classes": {
+              "version": "6.24.1",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+              "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+              "dev": true,
+              "requires": {
+                "babel-helper-define-map": "^6.24.1",
+                "babel-helper-function-name": "^6.24.1",
+                "babel-helper-optimise-call-expression": "^6.24.1",
+                "babel-helper-replace-supers": "^6.24.1",
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
+              }
+            },
+            "babel-plugin-transform-es2015-computed-properties": {
+              "version": "6.24.1",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+              "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+              "dev": true,
+              "requires": {
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
+              }
+            },
+            "babel-plugin-transform-es2015-destructuring": {
+              "version": "6.23.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+              "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+              "dev": true,
+              "requires": {
+                "babel-runtime": "^6.22.0"
+              }
+            },
+            "babel-plugin-transform-es2015-duplicate-keys": {
+              "version": "6.24.1",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+              "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+              "dev": true,
+              "requires": {
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
+              }
+            },
+            "babel-plugin-transform-es2015-for-of": {
+              "version": "6.23.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+              "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+              "dev": true,
+              "requires": {
+                "babel-runtime": "^6.22.0"
+              }
+            },
+            "babel-plugin-transform-es2015-function-name": {
+              "version": "6.24.1",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+              "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+              "dev": true,
+              "requires": {
+                "babel-helper-function-name": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
+              }
+            },
+            "babel-plugin-transform-es2015-literals": {
+              "version": "6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+              "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+              "dev": true,
+              "requires": {
+                "babel-runtime": "^6.22.0"
+              }
+            },
+            "babel-plugin-transform-es2015-modules-amd": {
+              "version": "6.24.1",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+              "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+              "dev": true,
+              "requires": {
+                "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
+              }
+            },
+            "babel-plugin-transform-es2015-modules-commonjs": {
+              "version": "6.26.2",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+              "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
+              "dev": true,
+              "requires": {
+                "babel-plugin-transform-strict-mode": "^6.24.1",
+                "babel-runtime": "^6.26.0",
+                "babel-template": "^6.26.0",
+                "babel-types": "^6.26.0"
+              }
+            },
+            "babel-plugin-transform-es2015-modules-systemjs": {
+              "version": "6.24.1",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+              "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+              "dev": true,
+              "requires": {
+                "babel-helper-hoist-variables": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
+              }
+            },
+            "babel-plugin-transform-es2015-modules-umd": {
+              "version": "6.24.1",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+              "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+              "dev": true,
+              "requires": {
+                "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
+              }
+            },
+            "babel-plugin-transform-es2015-object-super": {
+              "version": "6.24.1",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+              "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+              "dev": true,
+              "requires": {
+                "babel-helper-replace-supers": "^6.24.1",
+                "babel-runtime": "^6.22.0"
+              }
+            },
+            "babel-plugin-transform-es2015-parameters": {
+              "version": "6.24.1",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+              "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+              "dev": true,
+              "requires": {
+                "babel-helper-call-delegate": "^6.24.1",
+                "babel-helper-get-function-arity": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
+              }
+            },
+            "babel-plugin-transform-es2015-shorthand-properties": {
+              "version": "6.24.1",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+              "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+              "dev": true,
+              "requires": {
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
+              }
+            },
+            "babel-plugin-transform-es2015-spread": {
+              "version": "6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+              "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+              "dev": true,
+              "requires": {
+                "babel-runtime": "^6.22.0"
+              }
+            },
+            "babel-plugin-transform-es2015-sticky-regex": {
+              "version": "6.24.1",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+              "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+              "dev": true,
+              "requires": {
+                "babel-helper-regex": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
+              }
+            },
+            "babel-plugin-transform-es2015-template-literals": {
+              "version": "6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+              "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+              "dev": true,
+              "requires": {
+                "babel-runtime": "^6.22.0"
+              }
+            },
+            "babel-plugin-transform-es2015-typeof-symbol": {
+              "version": "6.23.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+              "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+              "dev": true,
+              "requires": {
+                "babel-runtime": "^6.22.0"
+              }
+            },
+            "babel-plugin-transform-es2015-unicode-regex": {
+              "version": "6.24.1",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+              "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+              "dev": true,
+              "requires": {
+                "babel-helper-regex": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "regexpu-core": "^2.0.0"
+              }
+            },
+            "babel-plugin-transform-exponentiation-operator": {
+              "version": "6.24.1",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+              "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+              "dev": true,
+              "requires": {
+                "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+                "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+                "babel-runtime": "^6.22.0"
+              }
+            },
+            "babel-plugin-transform-regenerator": {
+              "version": "6.26.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
+              "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+              "dev": true,
+              "requires": {
+                "regenerator-transform": "^0.10.0"
+              }
+            },
+            "babel-plugin-transform-strict-mode": {
+              "version": "6.24.1",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+              "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+              "dev": true,
+              "requires": {
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
+              }
+            },
+            "babel-preset-env": {
+              "version": "1.7.0",
+              "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
+              "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
+              "dev": true,
+              "requires": {
+                "babel-plugin-check-es2015-constants": "^6.22.0",
+                "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+                "babel-plugin-transform-async-to-generator": "^6.22.0",
+                "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+                "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+                "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
+                "babel-plugin-transform-es2015-classes": "^6.23.0",
+                "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
+                "babel-plugin-transform-es2015-destructuring": "^6.23.0",
+                "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
+                "babel-plugin-transform-es2015-for-of": "^6.23.0",
+                "babel-plugin-transform-es2015-function-name": "^6.22.0",
+                "babel-plugin-transform-es2015-literals": "^6.22.0",
+                "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+                "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+                "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
+                "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
+                "babel-plugin-transform-es2015-object-super": "^6.22.0",
+                "babel-plugin-transform-es2015-parameters": "^6.23.0",
+                "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
+                "babel-plugin-transform-es2015-spread": "^6.22.0",
+                "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
+                "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+                "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
+                "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
+                "babel-plugin-transform-exponentiation-operator": "^6.22.0",
+                "babel-plugin-transform-regenerator": "^6.22.0",
+                "browserslist": "^3.2.6",
+                "invariant": "^2.2.2",
+                "semver": "^5.3.0"
+              }
+            },
+            "babel-register": {
+              "version": "6.26.0",
+              "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+              "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+              "dev": true,
+              "requires": {
+                "babel-core": "^6.26.0",
+                "babel-runtime": "^6.26.0",
+                "core-js": "^2.5.0",
+                "home-or-tmp": "^2.0.0",
+                "lodash": "^4.17.4",
+                "mkdirp": "^0.5.1",
+                "source-map-support": "^0.4.15"
+              },
+              "dependencies": {
+                "source-map-support": {
+                  "version": "0.4.18",
+                  "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+                  "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+                  "dev": true,
+                  "requires": {
+                    "source-map": "^0.5.6"
+                  }
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.26.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+              "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+              "dev": true,
+              "requires": {
+                "core-js": "^2.4.0",
+                "regenerator-runtime": "^0.11.0"
+              }
+            },
+            "babel-template": {
+              "version": "6.26.0",
+              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+              "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+              "dev": true,
+              "requires": {
+                "babel-runtime": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "lodash": "^4.17.4"
+              }
+            },
+            "babel-traverse": {
+              "version": "6.26.0",
+              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+              "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+              "dev": true,
+              "requires": {
+                "babel-code-frame": "^6.26.0",
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "debug": "^2.6.8",
+                "globals": "^9.18.0",
+                "invariant": "^2.2.2",
+                "lodash": "^4.17.4"
+              },
+              "dependencies": {
+                "debug": {
+                  "version": "2.6.9",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                  "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                  "dev": true,
+                  "requires": {
+                    "ms": "2.0.0"
+                  }
+                }
+              }
+            },
+            "babel-types": {
+              "version": "6.26.0",
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+              "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+              "dev": true,
+              "requires": {
+                "babel-runtime": "^6.26.0",
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.4",
+                "to-fast-properties": "^1.0.3"
+              }
+            },
+            "babelify": {
+              "version": "7.3.0",
+              "resolved": "http://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
+              "integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
+              "dev": true,
+              "requires": {
+                "babel-core": "^6.0.14",
+                "object-assign": "^4.0.0"
+              }
+            },
+            "babylon": {
+              "version": "6.18.0",
+              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+              "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+              "dev": true
+            },
+            "backoff": {
+              "version": "2.5.0",
+              "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
+              "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
+              "dev": true,
+              "requires": {
+                "precond": "0.2"
+              }
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+            },
+            "base-x": {
+              "version": "3.0.5",
+              "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.5.tgz",
+              "integrity": "sha512-C3picSgzPSLE+jW3tcBzJoGwitOtazb5B+5YmAxZm2ybmTi9LNgAtDO/jjVEBZwHoXmDBZ9m/IELj3elJVRBcA==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "^5.0.1"
+              }
+            },
+            "base64-js": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+              "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+              "dev": true,
+              "optional": true
+            },
+            "bcrypt-pbkdf": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+              "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+              "dev": true,
+              "requires": {
+                "tweetnacl": "^0.14.3"
+              }
+            },
+            "bindings": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
+              "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
+            },
+            "bip39": {
+              "version": "2.5.0",
+              "resolved": "https://registry.npmjs.org/bip39/-/bip39-2.5.0.tgz",
+              "integrity": "sha512-xwIx/8JKoT2+IPJpFEfXoWdYwP7UVAoUxxLNfGCfVowaJE7yg1Y5B1BVPqlUNsBq5/nGwmFkwRJ8xDW4sX8OdA==",
+              "dev": true,
+              "requires": {
+                "create-hash": "^1.1.0",
+                "pbkdf2": "^3.0.9",
+                "randombytes": "^2.0.1",
+                "safe-buffer": "^5.0.1",
+                "unorm": "^1.3.3"
+              }
+            },
+            "bip66": {
+              "version": "1.1.5",
+              "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
+              "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+              "requires": {
+                "safe-buffer": "^5.0.1"
+              }
+            },
+            "bl": {
+              "version": "1.2.2",
+              "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+              "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+              "dev": true,
+              "requires": {
+                "readable-stream": "^2.3.5",
+                "safe-buffer": "^5.1.1"
+              }
+            },
+            "block-stream": {
+              "version": "0.0.9",
+              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+              "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "inherits": "~2.0.0"
+              }
+            },
+            "bluebird": {
+              "version": "3.5.3",
+              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+              "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
+              "dev": true,
+              "optional": true
+            },
+            "bn.js": {
+              "version": "4.11.8",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+            },
+            "body-parser": {
+              "version": "1.18.3",
+              "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+              "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
+              "dev": true,
+              "requires": {
+                "bytes": "3.0.0",
+                "content-type": "~1.0.4",
+                "debug": "2.6.9",
+                "depd": "~1.1.2",
+                "http-errors": "~1.6.3",
+                "iconv-lite": "0.4.23",
+                "on-finished": "~2.3.0",
+                "qs": "6.5.2",
+                "raw-body": "2.3.3",
+                "type-is": "~1.6.16"
+              },
+              "dependencies": {
+                "debug": {
+                  "version": "2.6.9",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                  "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                  "dev": true,
+                  "requires": {
+                    "ms": "2.0.0"
+                  }
+                }
+              }
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+              "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "brorand": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+              "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+            },
+            "browserify-aes": {
+              "version": "1.2.0",
+              "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+              "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+              "requires": {
+                "buffer-xor": "^1.0.3",
+                "cipher-base": "^1.0.0",
+                "create-hash": "^1.1.0",
+                "evp_bytestokey": "^1.0.3",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+              }
+            },
+            "browserify-cipher": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+              "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "browserify-aes": "^1.0.4",
+                "browserify-des": "^1.0.0",
+                "evp_bytestokey": "^1.0.0"
+              }
+            },
+            "browserify-des": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+              "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "cipher-base": "^1.0.1",
+                "des.js": "^1.0.0",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.1.2"
+              }
+            },
+            "browserify-rsa": {
+              "version": "4.0.1",
+              "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+              "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+              "dev": true,
+              "requires": {
+                "bn.js": "^4.1.0",
+                "randombytes": "^2.0.1"
+              }
+            },
+            "browserify-sha3": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/browserify-sha3/-/browserify-sha3-0.0.1.tgz",
+              "integrity": "sha1-P/NKMAbvFcD7NWflQbkaI0ASPRE=",
+              "dev": true,
+              "requires": {
+                "js-sha3": "^0.3.1"
+              }
+            },
+            "browserify-sign": {
+              "version": "4.0.4",
+              "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+              "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "bn.js": "^4.1.1",
+                "browserify-rsa": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "create-hmac": "^1.1.2",
+                "elliptic": "^6.0.0",
+                "inherits": "^2.0.1",
+                "parse-asn1": "^5.0.0"
+              }
+            },
+            "browserslist": {
+              "version": "3.2.8",
+              "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
+              "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
+              "dev": true,
+              "requires": {
+                "caniuse-lite": "^1.0.30000844",
+                "electron-to-chromium": "^1.3.47"
+              }
+            },
+            "bs58": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+              "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "base-x": "^3.0.2"
+              }
+            },
+            "bs58check": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+              "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "bs58": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "safe-buffer": "^5.1.2"
+              }
+            },
+            "buffer": {
+              "version": "5.2.1",
+              "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
+              "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4"
+              }
+            },
+            "buffer-alloc": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+              "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+              "dev": true,
+              "requires": {
+                "buffer-alloc-unsafe": "^1.1.0",
+                "buffer-fill": "^1.0.0"
+              }
+            },
+            "buffer-alloc-unsafe": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+              "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+              "dev": true
+            },
+            "buffer-crc32": {
+              "version": "0.2.13",
+              "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+              "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+              "dev": true,
+              "optional": true
+            },
+            "buffer-fill": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+              "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
+              "dev": true
+            },
+            "buffer-from": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+              "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+              "dev": true
+            },
+            "buffer-to-arraybuffer": {
+              "version": "0.0.5",
+              "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
+              "integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo=",
+              "dev": true
+            },
+            "buffer-xor": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+              "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+            },
+            "builtin-modules": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+              "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+              "dev": true
+            },
+            "bytes": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+              "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+              "dev": true
+            },
+            "bytewise": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
+              "integrity": "sha1-HRPL/3F65xWAlKqIGzXQgbOHJT4=",
+              "dev": true,
+              "requires": {
+                "bytewise-core": "^1.2.2",
+                "typewise": "^1.0.3"
+              }
+            },
+            "bytewise-core": {
+              "version": "1.2.3",
+              "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
+              "integrity": "sha1-P7QQx+kVWOsasiqCg0V3qmvWHUI=",
+              "dev": true,
+              "requires": {
+                "typewise-core": "^1.2"
+              }
+            },
+            "cachedown": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/cachedown/-/cachedown-1.0.0.tgz",
+              "integrity": "sha1-1D8DbkUQaWsxJG19sx6/D3rDLRU=",
+              "dev": true,
+              "requires": {
+                "abstract-leveldown": "^2.4.1",
+                "lru-cache": "^3.2.0"
+              },
+              "dependencies": {
+                "abstract-leveldown": {
+                  "version": "2.7.2",
+                  "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
+                  "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
+                  "dev": true,
+                  "requires": {
+                    "xtend": "~4.0.0"
+                  }
+                }
+              }
+            },
+            "camelcase": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+              "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+              "dev": true
+            },
+            "caniuse-lite": {
+              "version": "1.0.30000907",
+              "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000907.tgz",
+              "integrity": "sha512-No5sQ/OB2Nmka8MNOOM6nJx+Hxt6MQ6h7t7kgJFu9oTuwjykyKRSBP/+i/QAyFHxeHB+ddE0Da1CG5ihx9oehQ==",
+              "dev": true
+            },
+            "caseless": {
+              "version": "0.12.0",
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+              "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+              "dev": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              }
+            },
+            "checkpoint-store": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/checkpoint-store/-/checkpoint-store-1.1.0.tgz",
+              "integrity": "sha1-BOTLUWuRQziTWB5tRgGnjpVS6gY=",
+              "dev": true,
+              "requires": {
+                "functional-red-black-tree": "^1.0.1"
+              }
+            },
+            "cipher-base": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+              "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+              "requires": {
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+              }
+            },
+            "cliui": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+              "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+              "dev": true,
+              "requires": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wrap-ansi": "^2.0.0"
+              }
+            },
+            "clone": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+              "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+              "dev": true
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+              "dev": true
+            },
+            "coinstring": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/coinstring/-/coinstring-2.3.0.tgz",
+              "integrity": "sha1-zbYzY6lhUCQEolr7gsLibV/2J6Q=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "bs58": "^2.0.1",
+                "create-hash": "^1.1.1"
+              },
+              "dependencies": {
+                "bs58": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/bs58/-/bs58-2.0.1.tgz",
+                  "integrity": "sha1-VZCNWPGYKrogCPob7Y+RmYopv40=",
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            },
+            "combined-stream": {
+              "version": "1.0.7",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+              "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+              "dev": true,
+              "requires": {
+                "delayed-stream": "~1.0.0"
+              }
+            },
+            "commander": {
+              "version": "2.8.1",
+              "resolved": "http://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+              "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+              "dev": true,
+              "requires": {
+                "graceful-readlink": ">= 1.0.0"
+              }
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+            },
+            "concat-stream": {
+              "version": "1.6.2",
+              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+              "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+              "dev": true,
+              "requires": {
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
+              }
+            },
+            "content-disposition": {
+              "version": "0.5.2",
+              "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+              "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
+              "dev": true
+            },
+            "content-type": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+              "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+              "dev": true
+            },
+            "convert-source-map": {
+              "version": "1.6.0",
+              "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+              "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.1"
+              }
+            },
+            "cookie": {
+              "version": "0.3.1",
+              "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+              "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+              "dev": true
+            },
+            "cookie-signature": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+              "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+              "dev": true
+            },
+            "cookiejar": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+              "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
+              "dev": true
+            },
+            "core-js": {
+              "version": "2.5.7",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+              "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+              "dev": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+              "dev": true
+            },
+            "cors": {
+              "version": "2.8.5",
+              "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+              "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+              "dev": true,
+              "requires": {
+                "object-assign": "^4",
+                "vary": "^1"
+              }
+            },
+            "create-ecdh": {
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
+              "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "bn.js": "^4.1.0",
+                "elliptic": "^6.0.0"
+              }
+            },
+            "create-hash": {
+              "version": "1.2.0",
+              "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+              "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+              "requires": {
+                "cipher-base": "^1.0.1",
+                "inherits": "^2.0.1",
+                "md5.js": "^1.3.4",
+                "ripemd160": "^2.0.1",
+                "sha.js": "^2.4.0"
+              }
+            },
+            "create-hmac": {
+              "version": "1.1.7",
+              "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+              "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+              "requires": {
+                "cipher-base": "^1.0.3",
+                "create-hash": "^1.1.0",
+                "inherits": "^2.0.1",
+                "ripemd160": "^2.0.0",
+                "safe-buffer": "^5.0.1",
+                "sha.js": "^2.4.8"
+              }
+            },
+            "cross-fetch": {
+              "version": "2.2.3",
+              "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.3.tgz",
+              "integrity": "sha512-PrWWNH3yL2NYIb/7WF/5vFG3DCQiXDOVf8k3ijatbrtnwNuhMWLC7YF7uqf53tbTFDzHIUD8oITw4Bxt8ST3Nw==",
+              "dev": true,
+              "requires": {
+                "node-fetch": "2.1.2",
+                "whatwg-fetch": "2.0.4"
+              }
+            },
+            "crypto-browserify": {
+              "version": "3.12.0",
+              "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+              "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "browserify-cipher": "^1.0.0",
+                "browserify-sign": "^4.0.0",
+                "create-ecdh": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "create-hmac": "^1.1.0",
+                "diffie-hellman": "^5.0.0",
+                "inherits": "^2.0.1",
+                "pbkdf2": "^3.0.3",
+                "public-encrypt": "^4.0.0",
+                "randombytes": "^2.0.0",
+                "randomfill": "^1.0.3"
+              }
+            },
+            "dashdash": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+              "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+              "dev": true,
+              "requires": {
+                "assert-plus": "^1.0.0"
+              }
+            },
+            "debug": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "decamelize": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+              "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+              "dev": true
+            },
+            "decode-uri-component": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+              "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+              "dev": true
+            },
+            "decompress": {
+              "version": "4.2.0",
+              "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
+              "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "decompress-tar": "^4.0.0",
+                "decompress-tarbz2": "^4.0.0",
+                "decompress-targz": "^4.0.0",
+                "decompress-unzip": "^4.0.1",
+                "graceful-fs": "^4.1.10",
+                "make-dir": "^1.0.0",
+                "pify": "^2.3.0",
+                "strip-dirs": "^2.0.0"
+              },
+              "dependencies": {
+                "pify": {
+                  "version": "2.3.0",
+                  "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                  "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            },
+            "decompress-response": {
+              "version": "3.3.0",
+              "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+              "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+              "dev": true,
+              "requires": {
+                "mimic-response": "^1.0.0"
+              }
+            },
+            "decompress-tar": {
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
+              "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
+              "dev": true,
+              "requires": {
+                "file-type": "^5.2.0",
+                "is-stream": "^1.1.0",
+                "tar-stream": "^1.5.2"
+              }
+            },
+            "decompress-tarbz2": {
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
+              "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "decompress-tar": "^4.1.0",
+                "file-type": "^6.1.0",
+                "is-stream": "^1.1.0",
+                "seek-bzip": "^1.0.5",
+                "unbzip2-stream": "^1.0.9"
+              },
+              "dependencies": {
+                "file-type": {
+                  "version": "6.2.0",
+                  "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
+                  "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            },
+            "decompress-targz": {
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
+              "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "decompress-tar": "^4.1.1",
+                "file-type": "^5.2.0",
+                "is-stream": "^1.1.0"
+              }
+            },
+            "decompress-unzip": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
+              "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "file-type": "^3.8.0",
+                "get-stream": "^2.2.0",
+                "pify": "^2.3.0",
+                "yauzl": "^2.4.2"
+              },
+              "dependencies": {
+                "file-type": {
+                  "version": "3.9.0",
+                  "resolved": "http://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+                  "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
+                  "dev": true,
+                  "optional": true
+                },
+                "get-stream": {
+                  "version": "2.3.1",
+                  "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+                  "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "object-assign": "^4.0.1",
+                    "pinkie-promise": "^2.0.0"
+                  }
+                },
+                "pify": {
+                  "version": "2.3.0",
+                  "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                  "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            },
+            "deep-equal": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+              "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+              "dev": true
+            },
+            "deferred-leveldown": {
+              "version": "1.2.2",
+              "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
+              "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
+              "dev": true,
+              "requires": {
+                "abstract-leveldown": "~2.6.0"
+              },
+              "dependencies": {
+                "abstract-leveldown": {
+                  "version": "2.6.3",
+                  "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
+                  "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
+                  "dev": true,
+                  "requires": {
+                    "xtend": "~4.0.0"
+                  }
+                }
+              }
+            },
+            "define-properties": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+              "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+              "dev": true,
+              "requires": {
+                "object-keys": "^1.0.12"
+              },
+              "dependencies": {
+                "object-keys": {
+                  "version": "1.0.12",
+                  "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+                  "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
+                  "dev": true
+                }
+              }
+            },
+            "defined": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+              "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+              "dev": true
+            },
+            "delayed-stream": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+              "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+              "dev": true
+            },
+            "depd": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+              "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+              "dev": true
+            },
+            "des.js": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+              "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0"
+              }
+            },
+            "destroy": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+              "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+              "dev": true
+            },
+            "detect-indent": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+              "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+              "dev": true,
+              "requires": {
+                "repeating": "^2.0.0"
+              }
+            },
+            "diffie-hellman": {
+              "version": "5.0.3",
+              "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+              "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "bn.js": "^4.1.0",
+                "miller-rabin": "^4.0.0",
+                "randombytes": "^2.0.0"
+              }
+            },
+            "dom-walk": {
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
+              "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=",
+              "dev": true
+            },
+            "drbg.js": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
+              "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
+              "requires": {
+                "browserify-aes": "^1.0.6",
+                "create-hash": "^1.1.2",
+                "create-hmac": "^1.1.4"
+              }
+            },
+            "duplexer3": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+              "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+              "dev": true
+            },
+            "ecc-jsbn": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+              "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+              "dev": true,
+              "requires": {
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
+              }
+            },
+            "ee-first": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+              "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+              "dev": true
+            },
+            "electron-to-chromium": {
+              "version": "1.3.84",
+              "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.84.tgz",
+              "integrity": "sha512-IYhbzJYOopiTaNWMBp7RjbecUBsbnbDneOP86f3qvS0G0xfzwNSvMJpTrvi5/Y1gU7tg2NAgeg8a8rCYvW9Whw==",
+              "dev": true
+            },
+            "elliptic": {
+              "version": "6.4.1",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
+              "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+              "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
+              }
+            },
+            "encodeurl": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+              "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+              "dev": true
+            },
+            "encoding": {
+              "version": "0.1.12",
+              "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+              "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+              "dev": true,
+              "requires": {
+                "iconv-lite": "~0.4.13"
+              }
+            },
+            "encoding-down": {
+              "version": "5.0.4",
+              "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-5.0.4.tgz",
+              "integrity": "sha512-8CIZLDcSKxgzT+zX8ZVfgNbu8Md2wq/iqa1Y7zyVR18QBEAc0Nmzuvj/N5ykSKpfGzjM8qxbaFntLPwnVoUhZw==",
+              "dev": true,
+              "requires": {
+                "abstract-leveldown": "^5.0.0",
+                "inherits": "^2.0.3",
+                "level-codec": "^9.0.0",
+                "level-errors": "^2.0.0",
+                "xtend": "^4.0.1"
+              },
+              "dependencies": {
+                "abstract-leveldown": {
+                  "version": "5.0.0",
+                  "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
+                  "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
+                  "dev": true,
+                  "requires": {
+                    "xtend": "~4.0.0"
+                  }
+                }
+              }
+            },
+            "end-of-stream": {
+              "version": "1.4.1",
+              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+              "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+              "dev": true,
+              "requires": {
+                "once": "^1.4.0"
+              }
+            },
+            "errno": {
+              "version": "0.1.7",
+              "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+              "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+              "dev": true,
+              "requires": {
+                "prr": "~1.0.1"
+              }
+            },
+            "error-ex": {
+              "version": "1.3.2",
+              "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+              "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+              "dev": true,
+              "requires": {
+                "is-arrayish": "^0.2.1"
+              }
+            },
+            "es-abstract": {
+              "version": "1.12.0",
+              "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
+              "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+              "dev": true,
+              "requires": {
+                "es-to-primitive": "^1.1.1",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.1",
+                "is-callable": "^1.1.3",
+                "is-regex": "^1.0.4"
+              }
+            },
+            "es-to-primitive": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+              "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+              "dev": true,
+              "requires": {
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
+              }
+            },
+            "escape-html": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+              "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+              "dev": true
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+              "dev": true
+            },
+            "esutils": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+              "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+              "dev": true
+            },
+            "etag": {
+              "version": "1.8.1",
+              "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+              "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+              "dev": true
+            },
+            "eth-block-tracker": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/eth-block-tracker/-/eth-block-tracker-3.0.1.tgz",
+              "integrity": "sha512-WUVxWLuhMmsfenfZvFO5sbl1qFY2IqUlw/FPVmjjdElpqLsZtSG+wPe9Dz7W/sB6e80HgFKknOmKk2eNlznHug==",
+              "dev": true,
+              "requires": {
+                "eth-query": "^2.1.0",
+                "ethereumjs-tx": "^1.3.3",
+                "ethereumjs-util": "^5.1.3",
+                "ethjs-util": "^0.1.3",
+                "json-rpc-engine": "^3.6.0",
+                "pify": "^2.3.0",
+                "tape": "^4.6.3"
+              },
+              "dependencies": {
+                "pify": {
+                  "version": "2.3.0",
+                  "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                  "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                  "dev": true
+                }
+              }
+            },
+            "eth-json-rpc-infura": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/eth-json-rpc-infura/-/eth-json-rpc-infura-3.1.2.tgz",
+              "integrity": "sha512-IuK5Iowfs6taluA/3Okmu6EfZcFMq6MQuyrUL1PrCoJstuuBr3TvVeSy3keDyxfbrjFB34nCo538I8G+qMtsbw==",
+              "dev": true,
+              "requires": {
+                "cross-fetch": "^2.1.1",
+                "eth-json-rpc-middleware": "^1.5.0",
+                "json-rpc-engine": "^3.4.0",
+                "json-rpc-error": "^2.0.0",
+                "tape": "^4.8.0"
+              }
+            },
+            "eth-json-rpc-middleware": {
+              "version": "1.6.0",
+              "resolved": "http://registry.npmjs.org/eth-json-rpc-middleware/-/eth-json-rpc-middleware-1.6.0.tgz",
+              "integrity": "sha512-tDVCTlrUvdqHKqivYMjtFZsdD7TtpNLBCfKAcOpaVs7orBMS/A8HWro6dIzNtTZIR05FAbJ3bioFOnZpuCew9Q==",
+              "dev": true,
+              "requires": {
+                "async": "^2.5.0",
+                "eth-query": "^2.1.2",
+                "eth-tx-summary": "^3.1.2",
+                "ethereumjs-block": "^1.6.0",
+                "ethereumjs-tx": "^1.3.3",
+                "ethereumjs-util": "^5.1.2",
+                "ethereumjs-vm": "^2.1.0",
+                "fetch-ponyfill": "^4.0.0",
+                "json-rpc-engine": "^3.6.0",
+                "json-rpc-error": "^2.0.0",
+                "json-stable-stringify": "^1.0.1",
+                "promise-to-callback": "^1.0.0",
+                "tape": "^4.6.3"
+              },
+              "dependencies": {
+                "ethereum-common": {
+                  "version": "0.2.0",
+                  "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
+                  "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA==",
+                  "dev": true
+                },
+                "ethereumjs-block": {
+                  "version": "1.7.1",
+                  "resolved": "http://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
+                  "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
+                  "dev": true,
+                  "requires": {
+                    "async": "^2.0.1",
+                    "ethereum-common": "0.2.0",
+                    "ethereumjs-tx": "^1.2.2",
+                    "ethereumjs-util": "^5.0.0",
+                    "merkle-patricia-tree": "^2.1.2"
+                  }
+                }
+              }
+            },
+            "eth-lib": {
+              "version": "0.1.27",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.27.tgz",
+              "integrity": "sha512-B8czsfkJYzn2UIEMwjc7Mbj+Cy72V+/OXH/tb44LV8jhrjizQJJ325xMOMyk3+ETa6r6oi0jsUY14+om8mQMWA==",
+              "dev": true,
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "keccakjs": "^0.2.1",
+                "nano-json-stream-parser": "^0.1.2",
+                "servify": "^0.1.12",
+                "ws": "^3.0.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "eth-query": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/eth-query/-/eth-query-2.1.2.tgz",
+              "integrity": "sha1-1nQdkAAQa1FRDHLbktY2VFam2l4=",
+              "dev": true,
+              "requires": {
+                "json-rpc-random-id": "^1.0.0",
+                "xtend": "^4.0.1"
+              }
+            },
+            "eth-sig-util": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.0.2.tgz",
+              "integrity": "sha512-tB6E8jf/aZQ943bo3+iojl8xRe3Jzcl+9OT6v8K7kWis6PdIX19SB2vYvN849cB9G9m/XLjYFK381SgdbsnpTA==",
+              "dev": true,
+              "requires": {
+                "ethereumjs-abi": "0.6.5",
+                "ethereumjs-util": "^5.1.1"
+              }
+            },
+            "eth-tx-summary": {
+              "version": "3.2.3",
+              "resolved": "https://registry.npmjs.org/eth-tx-summary/-/eth-tx-summary-3.2.3.tgz",
+              "integrity": "sha512-1gZpA5fKarJOVSb5OUlPnhDQuIazqAkI61zlVvf5LdG47nEgw+/qhyZnuj3CUdE/TLTKuRzPLeyXLjaB4qWTRQ==",
+              "dev": true,
+              "requires": {
+                "async": "^2.1.2",
+                "bn.js": "^4.11.8",
+                "clone": "^2.0.0",
+                "concat-stream": "^1.5.1",
+                "end-of-stream": "^1.1.0",
+                "eth-query": "^2.0.2",
+                "ethereumjs-block": "^1.4.1",
+                "ethereumjs-tx": "^1.1.1",
+                "ethereumjs-util": "^5.0.1",
+                "ethereumjs-vm": "2.3.4",
+                "through2": "^2.0.3",
+                "treeify": "^1.0.1",
+                "web3-provider-engine": "^13.3.2"
+              },
+              "dependencies": {
+                "eth-block-tracker": {
+                  "version": "2.3.1",
+                  "resolved": "https://registry.npmjs.org/eth-block-tracker/-/eth-block-tracker-2.3.1.tgz",
+                  "integrity": "sha512-NamWuMBIl8kmkJFVj8WzGatySTzQPQag4Xr677yFxdVtIxACFbL/dQowk0MzEqIKk93U1TwY3MjVU6mOcwZnKA==",
+                  "dev": true,
+                  "requires": {
+                    "async-eventemitter": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
+                    "eth-query": "^2.1.0",
+                    "ethereumjs-tx": "^1.3.3",
+                    "ethereumjs-util": "^5.1.3",
+                    "ethjs-util": "^0.1.3",
+                    "json-rpc-engine": "^3.6.0",
+                    "pify": "^2.3.0",
+                    "tape": "^4.6.3"
+                  },
+                  "dependencies": {
+                    "async-eventemitter": {
+                      "version": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
+                      "from": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
+                      "dev": true,
+                      "requires": {
+                        "async": "^2.4.0"
+                      }
+                    }
+                  }
+                },
+                "eth-sig-util": {
+                  "version": "1.4.2",
+                  "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
+                  "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
+                  "dev": true,
+                  "requires": {
+                    "ethereumjs-util": "^5.1.1"
+                  },
+                  "dependencies": {
+                    "ethereumjs-abi": {
+                      "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+                      "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+                      "requires": {
+                        "bn.js": "^4.10.0",
+                        "ethereumjs-util": "^5.0.0"
+                      }
+                    }
+                  }
+                },
+                "ethereum-common": {
+                  "version": "0.2.0",
+                  "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
+                  "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA==",
+                  "dev": true
+                },
+                "ethereumjs-abi": {
+                  "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+                  "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+                  "requires": {
+                    "bn.js": "^4.10.0",
+                    "ethereumjs-util": "^5.0.0"
+                  }
+                },
+                "ethereumjs-block": {
+                  "version": "1.7.1",
+                  "resolved": "http://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
+                  "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
+                  "dev": true,
+                  "requires": {
+                    "async": "^2.0.1",
+                    "ethereum-common": "0.2.0",
+                    "ethereumjs-tx": "^1.2.2",
+                    "ethereumjs-util": "^5.0.0",
+                    "merkle-patricia-tree": "^2.1.2"
+                  }
+                },
+                "ethereumjs-vm": {
+                  "version": "2.3.4",
+                  "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.3.4.tgz",
+                  "integrity": "sha512-Y4SlzNDqxrCO58jhp98HdnZVdjOqB+HC0hoU+N/DEp1aU+hFkRX/nru5F7/HkQRPIlA6aJlQp/xIA6xZs1kspw==",
+                  "dev": true,
+                  "requires": {
+                    "async": "^2.1.2",
+                    "async-eventemitter": "^0.2.2",
+                    "ethereum-common": "0.2.0",
+                    "ethereumjs-account": "^2.0.3",
+                    "ethereumjs-block": "~1.7.0",
+                    "ethereumjs-util": "^5.1.3",
+                    "fake-merkle-patricia-tree": "^1.0.1",
+                    "functional-red-black-tree": "^1.0.1",
+                    "merkle-patricia-tree": "^2.1.2",
+                    "rustbn.js": "~0.1.1",
+                    "safe-buffer": "^5.1.1"
+                  }
+                },
+                "fs-extra": {
+                  "version": "0.30.0",
+                  "resolved": "http://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+                  "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+                  "requires": {
+                    "graceful-fs": "^4.1.2",
+                    "jsonfile": "^2.1.0",
+                    "klaw": "^1.0.0",
+                    "path-is-absolute": "^1.0.0",
+                    "rimraf": "^2.2.8"
+                  }
+                },
+                "pify": {
+                  "version": "2.3.0",
+                  "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                  "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                  "dev": true
+                },
+                "rustbn.js": {
+                  "version": "0.1.2",
+                  "resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.1.2.tgz",
+                  "integrity": "sha512-bAkNqSHYdJdFsBC7Z11JgzYktL31HIpB2o70jZcGiL1U1TVtPyvaVhDrGWwS8uZtaqwW2k6NOPGZCqW/Dgh5Lg==",
+                  "dev": true
+                },
+                "web3-provider-engine": {
+                  "version": "13.8.0",
+                  "resolved": "http://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-13.8.0.tgz",
+                  "integrity": "sha512-fZXhX5VWwWpoFfrfocslyg6P7cN3YWPG/ASaevNfeO80R+nzgoPUBXcWQekSGSsNDkeRTis4aMmpmofYf1TNtQ==",
+                  "dev": true,
+                  "requires": {
+                    "async": "^2.5.0",
+                    "clone": "^2.0.0",
+                    "eth-block-tracker": "^2.2.2",
+                    "eth-sig-util": "^1.4.2",
+                    "ethereumjs-block": "^1.2.2",
+                    "ethereumjs-tx": "^1.2.0",
+                    "ethereumjs-util": "^5.1.1",
+                    "ethereumjs-vm": "^2.0.2",
+                    "fetch-ponyfill": "^4.0.0",
+                    "json-rpc-error": "^2.0.0",
+                    "json-stable-stringify": "^1.0.1",
+                    "promise-to-callback": "^1.0.0",
+                    "readable-stream": "^2.2.9",
+                    "request": "^2.67.0",
+                    "semaphore": "^1.0.3",
+                    "solc": "^0.4.2",
+                    "tape": "^4.4.0",
+                    "xhr": "^2.2.0",
+                    "xtend": "^4.0.1"
+                  }
+                }
+              }
+            },
+            "ethereum-common": {
+              "version": "0.0.16",
+              "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.16.tgz",
+              "integrity": "sha1-mh4Wnq00q3XgifUMpRK/0PvRJlU=",
+              "dev": true
+            },
+            "ethereumjs-abi": {
+              "version": "0.6.5",
+              "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.5.tgz",
+              "integrity": "sha1-WmN+8Wq0NHP6cqKa2QhxQFs/UkE=",
+              "dev": true,
+              "requires": {
+                "bn.js": "^4.10.0",
+                "ethereumjs-util": "^4.3.0"
+              },
+              "dependencies": {
+                "ethereumjs-util": {
+                  "version": "4.5.0",
+                  "resolved": "http://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
+                  "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
+                  "dev": true,
+                  "requires": {
+                    "bn.js": "^4.8.0",
+                    "create-hash": "^1.1.2",
+                    "keccakjs": "^0.2.0",
+                    "rlp": "^2.0.0",
+                    "secp256k1": "^3.0.1"
+                  }
+                }
+              }
+            },
+            "ethereumjs-account": {
+              "version": "2.0.5",
+              "resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-2.0.5.tgz",
+              "integrity": "sha512-bgDojnXGjhMwo6eXQC0bY6UK2liSFUSMwwylOmQvZbSl/D7NXQ3+vrGO46ZeOgjGfxXmgIeVNDIiHw7fNZM4VA==",
+              "dev": true,
+              "requires": {
+                "ethereumjs-util": "^5.0.0",
+                "rlp": "^2.0.0",
+                "safe-buffer": "^5.1.1"
+              }
+            },
+            "ethereumjs-block": {
+              "version": "1.2.2",
+              "resolved": "http://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.2.2.tgz",
+              "integrity": "sha1-LsdTSlkCG47JuDww5JaQxuuu3aE=",
+              "dev": true,
+              "requires": {
+                "async": "^1.5.2",
+                "ethereum-common": "0.0.16",
+                "ethereumjs-tx": "^1.0.0",
+                "ethereumjs-util": "^4.0.1",
+                "merkle-patricia-tree": "^2.1.2"
+              },
+              "dependencies": {
+                "async": {
+                  "version": "1.5.2",
+                  "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                  "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+                  "dev": true
+                },
+                "ethereumjs-util": {
+                  "version": "4.5.0",
+                  "resolved": "http://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
+                  "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
+                  "dev": true,
+                  "requires": {
+                    "bn.js": "^4.8.0",
+                    "create-hash": "^1.1.2",
+                    "keccakjs": "^0.2.0",
+                    "rlp": "^2.0.0",
+                    "secp256k1": "^3.0.1"
+                  }
+                }
+              }
+            },
+            "ethereumjs-common": {
+              "version": "0.4.1",
+              "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-0.4.1.tgz",
+              "integrity": "sha512-ywYGsOeGCsMNWso5Y4GhjWI24FJv9FK7+VyVKiQgXg8ZRDPXJ7F/kJ1CnjtkjTvDF4e0yqU+FWswlqR3bmZQ9Q==",
+              "dev": true
+            },
+            "ethereumjs-tx": {
+              "version": "1.3.7",
+              "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
+              "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
+              "dev": true,
+              "requires": {
+                "ethereum-common": "^0.0.18",
+                "ethereumjs-util": "^5.0.0"
+              },
+              "dependencies": {
+                "ethereum-common": {
+                  "version": "0.0.18",
+                  "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
+                  "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8=",
+                  "dev": true
+                }
+              }
+            },
+            "ethereumjs-util": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+              "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+              "requires": {
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "ethjs-util": "^0.1.3",
+                "keccak": "^1.0.2",
+                "rlp": "^2.0.0",
+                "safe-buffer": "^5.1.1",
+                "secp256k1": "^3.0.1"
+              }
+            },
+            "ethereumjs-vm": {
+              "version": "2.4.0",
+              "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.4.0.tgz",
+              "integrity": "sha512-MJ4lCWa5c6LhahhhvoDKW+YGjK00ZQn0RHHLh4L+WaH1k6Qv7/q3uTluew6sJGNCZdlO0yYMDXYW9qyxLHKlgQ==",
+              "dev": true,
+              "requires": {
+                "async": "^2.1.2",
+                "async-eventemitter": "^0.2.2",
+                "ethereumjs-account": "^2.0.3",
+                "ethereumjs-block": "~1.7.0",
+                "ethereumjs-common": "~0.4.0",
+                "ethereumjs-util": "^5.2.0",
+                "fake-merkle-patricia-tree": "^1.0.1",
+                "functional-red-black-tree": "^1.0.1",
+                "merkle-patricia-tree": "^2.1.2",
+                "rustbn.js": "~0.2.0",
+                "safe-buffer": "^5.1.1"
+              },
+              "dependencies": {
+                "ethereum-common": {
+                  "version": "0.2.0",
+                  "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
+                  "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA==",
+                  "dev": true
+                },
+                "ethereumjs-block": {
+                  "version": "1.7.1",
+                  "resolved": "http://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
+                  "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
+                  "dev": true,
+                  "requires": {
+                    "async": "^2.0.1",
+                    "ethereum-common": "0.2.0",
+                    "ethereumjs-tx": "^1.2.2",
+                    "ethereumjs-util": "^5.0.0",
+                    "merkle-patricia-tree": "^2.1.2"
+                  }
+                }
+              }
+            },
+            "ethereumjs-wallet": {
+              "version": "0.6.2",
+              "resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-0.6.2.tgz",
+              "integrity": "sha512-DHEKPV9lYORM7dL8602dkb+AgdfzCYz2lxpdYQoD3OwG355LLDuivW9rGuLpDMCry/ORyBYV6n+QCo/71SwACg==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "aes-js": "^3.1.1",
+                "bs58check": "^2.1.2",
+                "ethereumjs-util": "^5.2.0",
+                "hdkey": "^1.0.0",
+                "safe-buffer": "^5.1.2",
+                "scrypt.js": "^0.2.0",
+                "utf8": "^3.0.0",
+                "uuid": "^3.3.2"
+              }
+            },
+            "ethjs-unit": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
+              "integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
+              "dev": true,
+              "requires": {
+                "bn.js": "4.11.6",
+                "number-to-bn": "1.7.0"
+              },
+              "dependencies": {
+                "bn.js": {
+                  "version": "4.11.6",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+                  "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+                  "dev": true
+                }
+              }
+            },
+            "ethjs-util": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
+              "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
+              "requires": {
+                "is-hex-prefixed": "1.0.0",
+                "strip-hex-prefix": "1.0.0"
+              }
+            },
+            "eventemitter3": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
+              "integrity": "sha1-R3hr2qCHyvext15zq8XH1UAVjNA=",
+              "dev": true
+            },
+            "events": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
+              "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA==",
+              "dev": true
+            },
+            "evp_bytestokey": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+              "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+              "requires": {
+                "md5.js": "^1.3.4",
+                "safe-buffer": "^5.1.1"
+              }
+            },
+            "express": {
+              "version": "4.16.4",
+              "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
+              "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
+              "dev": true,
+              "requires": {
+                "accepts": "~1.3.5",
+                "array-flatten": "1.1.1",
+                "body-parser": "1.18.3",
+                "content-disposition": "0.5.2",
+                "content-type": "~1.0.4",
+                "cookie": "0.3.1",
+                "cookie-signature": "1.0.6",
+                "debug": "2.6.9",
+                "depd": "~1.1.2",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
+                "finalhandler": "1.1.1",
+                "fresh": "0.5.2",
+                "merge-descriptors": "1.0.1",
+                "methods": "~1.1.2",
+                "on-finished": "~2.3.0",
+                "parseurl": "~1.3.2",
+                "path-to-regexp": "0.1.7",
+                "proxy-addr": "~2.0.4",
+                "qs": "6.5.2",
+                "range-parser": "~1.2.0",
+                "safe-buffer": "5.1.2",
+                "send": "0.16.2",
+                "serve-static": "1.13.2",
+                "setprototypeof": "1.1.0",
+                "statuses": "~1.4.0",
+                "type-is": "~1.6.16",
+                "utils-merge": "1.0.1",
+                "vary": "~1.1.2"
+              },
+              "dependencies": {
+                "debug": {
+                  "version": "2.6.9",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                  "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                  "dev": true,
+                  "requires": {
+                    "ms": "2.0.0"
+                  }
+                },
+                "statuses": {
+                  "version": "1.4.0",
+                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+                  "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+                  "dev": true
+                }
+              }
+            },
+            "extend": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+              "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+              "dev": true
+            },
+            "extsprintf": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+              "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+              "dev": true
+            },
+            "fake-merkle-patricia-tree": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/fake-merkle-patricia-tree/-/fake-merkle-patricia-tree-1.0.1.tgz",
+              "integrity": "sha1-S4w6z7Ugr635hgsfFM2M40As3dM=",
+              "dev": true,
+              "requires": {
+                "checkpoint-store": "^1.1.0"
+              }
+            },
+            "fast-deep-equal": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+              "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+              "dev": true
+            },
+            "fast-json-stable-stringify": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+              "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+              "dev": true
+            },
+            "fd-slicer": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+              "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "pend": "~1.2.0"
+              }
+            },
+            "fetch-ponyfill": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/fetch-ponyfill/-/fetch-ponyfill-4.1.0.tgz",
+              "integrity": "sha1-rjzl9zLGReq4fkroeTQUcJsjmJM=",
+              "dev": true,
+              "requires": {
+                "node-fetch": "~1.7.1"
+              },
+              "dependencies": {
+                "node-fetch": {
+                  "version": "1.7.3",
+                  "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+                  "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+                  "dev": true,
+                  "requires": {
+                    "encoding": "^0.1.11",
+                    "is-stream": "^1.0.1"
+                  }
+                }
+              }
+            },
+            "file-type": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
+              "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
+              "dev": true
+            },
+            "finalhandler": {
+              "version": "1.1.1",
+              "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+              "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+              "dev": true,
+              "requires": {
+                "debug": "2.6.9",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "on-finished": "~2.3.0",
+                "parseurl": "~1.3.2",
+                "statuses": "~1.4.0",
+                "unpipe": "~1.0.0"
+              },
+              "dependencies": {
+                "debug": {
+                  "version": "2.6.9",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                  "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                  "dev": true,
+                  "requires": {
+                    "ms": "2.0.0"
+                  }
+                },
+                "statuses": {
+                  "version": "1.4.0",
+                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+                  "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+                  "dev": true
+                }
+              }
+            },
+            "find-up": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+              "dev": true,
+              "requires": {
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "for-each": {
+              "version": "0.3.3",
+              "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+              "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+              "dev": true,
+              "requires": {
+                "is-callable": "^1.1.3"
+              }
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+              "dev": true
+            },
+            "form-data": {
+              "version": "2.3.3",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+              "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+              "dev": true,
+              "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12"
+              }
+            },
+            "forwarded": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+              "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+              "dev": true
+            },
+            "fresh": {
+              "version": "0.5.2",
+              "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+              "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+              "dev": true
+            },
+            "fs-constants": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+              "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+              "dev": true
+            },
+            "fs-extra": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
+              "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^2.1.0"
+              }
+            },
+            "fs-promise": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/fs-promise/-/fs-promise-2.0.3.tgz",
+              "integrity": "sha1-9k5PhUvPaJqovdy6JokW2z20aFQ=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "any-promise": "^1.3.0",
+                "fs-extra": "^2.0.0",
+                "mz": "^2.6.0",
+                "thenify-all": "^1.6.0"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+            },
+            "fstream": {
+              "version": "1.0.11",
+              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+              "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
+              }
+            },
+            "function-bind": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+              "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+              "dev": true
+            },
+            "functional-red-black-tree": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+              "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+              "dev": true
+            },
+            "get-caller-file": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+              "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+              "dev": true
+            },
+            "get-stream": {
+              "version": "3.0.0",
+              "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+              "dev": true
+            },
+            "getpass": {
+              "version": "0.1.7",
+              "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+              "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+              "dev": true,
+              "requires": {
+                "assert-plus": "^1.0.0"
+              }
+            },
+            "glob": {
+              "version": "7.1.3",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+              "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "global": {
+              "version": "4.3.2",
+              "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
+              "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+              "dev": true,
+              "requires": {
+                "min-document": "^2.19.0",
+                "process": "~0.5.1"
+              }
+            },
+            "globals": {
+              "version": "9.18.0",
+              "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+              "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+              "dev": true
+            },
+            "got": {
+              "version": "7.1.0",
+              "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+              "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+              "dev": true,
+              "requires": {
+                "decompress-response": "^3.2.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^3.0.0",
+                "is-plain-obj": "^1.1.0",
+                "is-retry-allowed": "^1.0.0",
+                "is-stream": "^1.0.0",
+                "isurl": "^1.0.0-alpha5",
+                "lowercase-keys": "^1.0.0",
+                "p-cancelable": "^0.3.0",
+                "p-timeout": "^1.1.1",
+                "safe-buffer": "^5.0.1",
+                "timed-out": "^4.0.0",
+                "url-parse-lax": "^1.0.0",
+                "url-to-options": "^1.0.1"
+              }
+            },
+            "graceful-fs": {
+              "version": "4.1.15",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+              "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
+            },
+            "graceful-readlink": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+              "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+              "dev": true
+            },
+            "har-schema": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+              "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+              "dev": true
+            },
+            "har-validator": {
+              "version": "5.1.3",
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+              "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+              "dev": true,
+              "requires": {
+                "ajv": "^6.5.5",
+                "har-schema": "^2.0.0"
+              }
+            },
+            "has": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+              "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+              "dev": true,
+              "requires": {
+                "function-bind": "^1.1.1"
+              }
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "has-symbol-support-x": {
+              "version": "1.4.2",
+              "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
+              "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
+              "dev": true
+            },
+            "has-symbols": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+              "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+              "dev": true
+            },
+            "has-to-string-tag-x": {
+              "version": "1.4.1",
+              "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+              "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+              "dev": true,
+              "requires": {
+                "has-symbol-support-x": "^1.4.1"
+              }
+            },
+            "hash-base": {
+              "version": "3.0.4",
+              "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+              "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+              "requires": {
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+              }
+            },
+            "hash.js": {
+              "version": "1.1.5",
+              "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.5.tgz",
+              "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
+              "requires": {
+                "inherits": "^2.0.3",
+                "minimalistic-assert": "^1.0.1"
+              }
+            },
+            "hdkey": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/hdkey/-/hdkey-1.1.0.tgz",
+              "integrity": "sha512-E7aU8pNlWUJbXGjTz/+lKf1LkMcA3hUrC5ZleeizrmLSd++kvf8mSOe3q8CmBDA9j4hdfXO5iY6hGiTUCOV2jQ==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "coinstring": "^2.0.0",
+                "safe-buffer": "^5.1.1",
+                "secp256k1": "^3.0.1"
+              }
+            },
+            "heap": {
+              "version": "0.2.6",
+              "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz",
+              "integrity": "sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw=",
+              "dev": true
+            },
+            "hmac-drbg": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+              "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+              "requires": {
+                "hash.js": "^1.0.3",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.1"
+              }
+            },
+            "home-or-tmp": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+              "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+              "dev": true,
+              "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.1"
+              }
+            },
+            "hosted-git-info": {
+              "version": "2.7.1",
+              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+              "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+              "dev": true
+            },
+            "http-errors": {
+              "version": "1.6.3",
+              "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+              "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+              "dev": true,
+              "requires": {
+                "depd": "~1.1.2",
+                "inherits": "2.0.3",
+                "setprototypeof": "1.1.0",
+                "statuses": ">= 1.4.0 < 2"
+              }
+            },
+            "http-https": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
+              "integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs=",
+              "dev": true
+            },
+            "http-signature": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+              "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+              "dev": true,
+              "requires": {
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
+              }
+            },
+            "iconv-lite": {
+              "version": "0.4.23",
+              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+              "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+              "dev": true,
+              "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+              }
+            },
+            "ieee754": {
+              "version": "1.1.12",
+              "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
+              "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
+              "dev": true
+            },
+            "immediate": {
+              "version": "3.2.3",
+              "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
+              "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=",
+              "dev": true
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+            },
+            "invariant": {
+              "version": "2.2.4",
+              "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+              "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+              "dev": true,
+              "requires": {
+                "loose-envify": "^1.0.0"
+              }
+            },
+            "invert-kv": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+              "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+              "dev": true
+            },
+            "ipaddr.js": {
+              "version": "1.8.0",
+              "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
+              "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4=",
+              "dev": true
+            },
+            "is-arrayish": {
+              "version": "0.2.1",
+              "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+              "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+              "dev": true
+            },
+            "is-builtin-module": {
+              "version": "1.0.0",
+              "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+              "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+              "dev": true,
+              "requires": {
+                "builtin-modules": "^1.0.0"
+              }
+            },
+            "is-callable": {
+              "version": "1.1.4",
+              "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+              "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+              "dev": true
+            },
+            "is-date-object": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+              "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+              "dev": true
+            },
+            "is-finite": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+              "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+              "dev": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "is-fn": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-fn/-/is-fn-1.0.0.tgz",
+              "integrity": "sha1-lUPV3nvPWwiiLsiiC65uKG1RDYw=",
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+              "dev": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "is-function": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
+              "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU=",
+              "dev": true
+            },
+            "is-hex-prefixed": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
+              "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
+            },
+            "is-natural-number": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
+              "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg=",
+              "dev": true,
+              "optional": true
+            },
+            "is-object": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+              "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+              "dev": true
+            },
+            "is-plain-obj": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+              "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+              "dev": true
+            },
+            "is-regex": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+              "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+              "dev": true,
+              "requires": {
+                "has": "^1.0.1"
+              }
+            },
+            "is-retry-allowed": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+              "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+              "dev": true
+            },
+            "is-stream": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+              "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+              "dev": true
+            },
+            "is-symbol": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+              "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+              "dev": true,
+              "requires": {
+                "has-symbols": "^1.0.0"
+              }
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+            },
+            "is-utf8": {
+              "version": "0.2.1",
+              "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+              "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+              "dev": true
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+              "dev": true
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+              "dev": true
+            },
+            "isurl": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
+              "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+              "dev": true,
+              "requires": {
+                "has-to-string-tag-x": "^1.2.0",
+                "is-object": "^1.0.1"
+              }
+            },
+            "js-sha3": {
+              "version": "0.3.1",
+              "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.3.1.tgz",
+              "integrity": "sha1-hhIoAhQvCChQKg0d7h2V4lO7AkM=",
+              "dev": true
+            },
+            "js-tokens": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+              "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+              "dev": true
+            },
+            "jsbn": {
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+              "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+              "dev": true
+            },
+            "jsesc": {
+              "version": "0.5.0",
+              "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+              "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+              "dev": true
+            },
+            "json-rpc-engine": {
+              "version": "3.8.0",
+              "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-3.8.0.tgz",
+              "integrity": "sha512-6QNcvm2gFuuK4TKU1uwfH0Qd/cOSb9c1lls0gbnIhciktIUQJwz6NQNAW4B1KiGPenv7IKu97V222Yo1bNhGuA==",
+              "dev": true,
+              "requires": {
+                "async": "^2.0.1",
+                "babel-preset-env": "^1.7.0",
+                "babelify": "^7.3.0",
+                "json-rpc-error": "^2.0.0",
+                "promise-to-callback": "^1.0.0",
+                "safe-event-emitter": "^1.0.1"
+              }
+            },
+            "json-rpc-error": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/json-rpc-error/-/json-rpc-error-2.0.0.tgz",
+              "integrity": "sha1-p6+cICg4tekFxyUOVH8a/3cligI=",
+              "dev": true,
+              "requires": {
+                "inherits": "^2.0.1"
+              }
+            },
+            "json-rpc-random-id": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/json-rpc-random-id/-/json-rpc-random-id-1.0.1.tgz",
+              "integrity": "sha1-uknZat7RRE27jaPSA3SKy7zeyMg=",
+              "dev": true
+            },
+            "json-schema": {
+              "version": "0.2.3",
+              "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+              "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+              "dev": true
+            },
+            "json-schema-traverse": {
+              "version": "0.4.1",
+              "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+              "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+              "dev": true
+            },
+            "json-stable-stringify": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+              "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+              "dev": true,
+              "requires": {
+                "jsonify": "~0.0.0"
+              }
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+              "dev": true
+            },
+            "json5": {
+              "version": "0.5.1",
+              "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+              "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+              "dev": true
+            },
+            "jsonfile": {
+              "version": "2.4.0",
+              "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+              "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+              "requires": {
+                "graceful-fs": "^4.1.6"
+              }
+            },
+            "jsonify": {
+              "version": "0.0.0",
+              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+              "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+              "dev": true
+            },
+            "jsprim": {
+              "version": "1.4.1",
+              "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+              "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+              "dev": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+              }
+            },
+            "keccak": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+              "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+              "requires": {
+                "bindings": "^1.2.1",
+                "inherits": "^2.0.3",
+                "nan": "^2.2.1",
+                "safe-buffer": "^5.1.0"
+              }
+            },
+            "keccakjs": {
+              "version": "0.2.1",
+              "resolved": "https://registry.npmjs.org/keccakjs/-/keccakjs-0.2.1.tgz",
+              "integrity": "sha1-HWM6+QfvMFu/ny+mFtVsRFYd+k0=",
+              "dev": true,
+              "requires": {
+                "browserify-sha3": "^0.0.1",
+                "sha3": "^1.1.0"
+              }
+            },
+            "klaw": {
+              "version": "1.3.1",
+              "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+              "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+              "requires": {
+                "graceful-fs": "^4.1.9"
+              }
+            },
+            "lcid": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+              "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+              "dev": true,
+              "requires": {
+                "invert-kv": "^1.0.0"
+              }
+            },
+            "level-codec": {
+              "version": "9.0.0",
+              "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.0.tgz",
+              "integrity": "sha512-OIpVvjCcZNP5SdhcNupnsI1zo5Y9Vpm+k/F1gfG5kXrtctlrwanisakweJtE0uA0OpLukRfOQae+Fg0M5Debhg==",
+              "dev": true
+            },
+            "level-errors": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.0.tgz",
+              "integrity": "sha512-AmY4HCp9h3OiU19uG+3YWkdELgy05OTP/r23aNHaQKWv8DO787yZgsEuGVkoph40uwN+YdUKnANlrxSsoOaaxg==",
+              "dev": true,
+              "requires": {
+                "errno": "~0.1.1"
+              }
+            },
+            "level-iterator-stream": {
+              "version": "1.3.1",
+              "resolved": "http://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
+              "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
+              "dev": true,
+              "requires": {
+                "inherits": "^2.0.1",
+                "level-errors": "^1.0.3",
+                "readable-stream": "^1.0.33",
+                "xtend": "^4.0.0"
+              },
+              "dependencies": {
+                "level-errors": {
+                  "version": "1.1.2",
+                  "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.1.2.tgz",
+                  "integrity": "sha512-Sw/IJwWbPKF5Ai4Wz60B52yj0zYeqzObLh8k1Tk88jVmD51cJSKWSYpRyhVIvFzZdvsPqlH5wfhp/yxdsaQH4w==",
+                  "dev": true,
+                  "requires": {
+                    "errno": "~0.1.1"
+                  }
+                },
+                "readable-stream": {
+                  "version": "1.1.14",
+                  "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                  "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+                  "dev": true,
+                  "requires": {
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.1",
+                    "isarray": "0.0.1",
+                    "string_decoder": "~0.10.x"
+                  }
+                }
+              }
+            },
+            "level-post": {
+              "version": "1.0.7",
+              "resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.7.tgz",
+              "integrity": "sha512-PWYqG4Q00asOrLhX7BejSajByB4EmG2GaKHfj3h5UmmZ2duciXLPGYWIjBzLECFWUGOZWlm5B20h/n3Gs3HKew==",
+              "dev": true,
+              "requires": {
+                "ltgt": "^2.1.2"
+              }
+            },
+            "level-sublevel": {
+              "version": "6.6.4",
+              "resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.4.tgz",
+              "integrity": "sha512-pcCrTUOiO48+Kp6F1+UAzF/OtWqLcQVTVF39HLdZ3RO8XBoXt+XVPKZO1vVr1aUoxHZA9OtD2e1v7G+3S5KFDA==",
+              "dev": true,
+              "requires": {
+                "bytewise": "~1.1.0",
+                "level-codec": "^9.0.0",
+                "level-errors": "^2.0.0",
+                "level-iterator-stream": "^2.0.3",
+                "ltgt": "~2.1.1",
+                "pull-defer": "^0.2.2",
+                "pull-level": "^2.0.3",
+                "pull-stream": "^3.6.8",
+                "typewiselite": "~1.0.0",
+                "xtend": "~4.0.0"
+              },
+              "dependencies": {
+                "level-iterator-stream": {
+                  "version": "2.0.3",
+                  "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.3.tgz",
+                  "integrity": "sha512-I6Heg70nfF+e5Y3/qfthJFexhRw/Gi3bIymCoXAlijZdAcLaPuWSJs3KXyTYf23ID6g0o2QF62Yh+grOXY3Rig==",
+                  "dev": true,
+                  "requires": {
+                    "inherits": "^2.0.1",
+                    "readable-stream": "^2.0.5",
+                    "xtend": "^4.0.0"
+                  }
+                },
+                "ltgt": {
+                  "version": "2.1.3",
+                  "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz",
+                  "integrity": "sha1-EIUaBtmWS5cReEQcI8nlJpjuzjQ=",
+                  "dev": true
+                }
+              }
+            },
+            "level-ws": {
+              "version": "0.0.0",
+              "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
+              "integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
+              "dev": true,
+              "requires": {
+                "readable-stream": "~1.0.15",
+                "xtend": "~2.1.1"
+              },
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.34",
+                  "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                  "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                  "dev": true,
+                  "requires": {
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.1",
+                    "isarray": "0.0.1",
+                    "string_decoder": "~0.10.x"
+                  }
+                },
+                "xtend": {
+                  "version": "2.1.2",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+                  "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+                  "dev": true,
+                  "requires": {
+                    "object-keys": "~0.4.0"
+                  }
+                }
+              }
+            },
+            "levelup": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/levelup/-/levelup-3.1.1.tgz",
+              "integrity": "sha512-9N10xRkUU4dShSRRFTBdNaBxofz+PGaIZO962ckboJZiNmLuhVT6FZ6ZKAsICKfUBO76ySaYU6fJWX/jnj3Lcg==",
+              "dev": true,
+              "requires": {
+                "deferred-leveldown": "~4.0.0",
+                "level-errors": "~2.0.0",
+                "level-iterator-stream": "~3.0.0",
+                "xtend": "~4.0.0"
+              },
+              "dependencies": {
+                "abstract-leveldown": {
+                  "version": "5.0.0",
+                  "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
+                  "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
+                  "dev": true,
+                  "requires": {
+                    "xtend": "~4.0.0"
+                  }
+                },
+                "deferred-leveldown": {
+                  "version": "4.0.2",
+                  "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-4.0.2.tgz",
+                  "integrity": "sha512-5fMC8ek8alH16QiV0lTCis610D1Zt1+LA4MS4d63JgS32lrCjTFDUFz2ao09/j2I4Bqb5jL4FZYwu7Jz0XO1ww==",
+                  "dev": true,
+                  "requires": {
+                    "abstract-leveldown": "~5.0.0",
+                    "inherits": "^2.0.3"
+                  }
+                },
+                "level-iterator-stream": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-3.0.1.tgz",
+                  "integrity": "sha512-nEIQvxEED9yRThxvOrq8Aqziy4EGzrxSZK+QzEFAVuJvQ8glfyZ96GB6BoI4sBbLfjMXm2w4vu3Tkcm9obcY0g==",
+                  "dev": true,
+                  "requires": {
+                    "inherits": "^2.0.1",
+                    "readable-stream": "^2.3.6",
+                    "xtend": "^4.0.0"
+                  }
+                }
+              }
+            },
+            "load-json-file": {
+              "version": "1.1.0",
+              "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+              "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "strip-bom": "^2.0.0"
+              },
+              "dependencies": {
+                "pify": {
+                  "version": "2.3.0",
+                  "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                  "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                  "dev": true
+                }
+              }
+            },
+            "lodash": {
+              "version": "4.17.10",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+              "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+              "dev": true
+            },
+            "lodash.assign": {
+              "version": "4.2.0",
+              "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+              "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+              "dev": true
+            },
+            "looper": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/looper/-/looper-2.0.0.tgz",
+              "integrity": "sha1-Zs0Md0rz1P7axTeU90LbVtqPCew=",
+              "dev": true
+            },
+            "loose-envify": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+              "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+              "dev": true,
+              "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+              }
+            },
+            "lowercase-keys": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+              "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+              "dev": true
+            },
+            "lru-cache": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
+              "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
+              "dev": true,
+              "requires": {
+                "pseudomap": "^1.0.1"
+              }
+            },
+            "ltgt": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+              "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU=",
+              "dev": true
+            },
+            "make-dir": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+              "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "pify": "^3.0.0"
+              },
+              "dependencies": {
+                "pify": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                  "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            },
+            "md5.js": {
+              "version": "1.3.5",
+              "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+              "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+              "requires": {
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.1.2"
+              }
+            },
+            "media-typer": {
+              "version": "0.3.0",
+              "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+              "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+              "dev": true
+            },
+            "memdown": {
+              "version": "1.4.1",
+              "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
+              "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
+              "dev": true,
+              "requires": {
+                "abstract-leveldown": "~2.7.1",
+                "functional-red-black-tree": "^1.0.1",
+                "immediate": "^3.2.3",
+                "inherits": "~2.0.1",
+                "ltgt": "~2.2.0",
+                "safe-buffer": "~5.1.1"
+              },
+              "dependencies": {
+                "abstract-leveldown": {
+                  "version": "2.7.2",
+                  "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
+                  "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
+                  "dev": true,
+                  "requires": {
+                    "xtend": "~4.0.0"
+                  }
+                }
+              }
+            },
+            "memorystream": {
+              "version": "0.3.1",
+              "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+              "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
+              "dev": true
+            },
+            "merge-descriptors": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+              "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+              "dev": true
+            },
+            "merkle-patricia-tree": {
+              "version": "2.3.1",
+              "resolved": "http://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.1.tgz",
+              "integrity": "sha512-Qp9Mpb3xazznXzzGQBqHbqCpT2AR9joUOHYYPiQjYCarrdCPCnLWXo4BFv77y4xN26KR224xoU1n/qYY7RYYgw==",
+              "dev": true,
+              "requires": {
+                "async": "^1.4.2",
+                "ethereumjs-util": "^5.0.0",
+                "level-ws": "0.0.0",
+                "levelup": "^1.2.1",
+                "memdown": "^1.0.0",
+                "readable-stream": "^2.0.0",
+                "rlp": "^2.0.0",
+                "semaphore": ">=1.0.1"
+              },
+              "dependencies": {
+                "async": {
+                  "version": "1.5.2",
+                  "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                  "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+                  "dev": true
+                },
+                "level-codec": {
+                  "version": "7.0.1",
+                  "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
+                  "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ==",
+                  "dev": true
+                },
+                "level-errors": {
+                  "version": "1.0.5",
+                  "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
+                  "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
+                  "dev": true,
+                  "requires": {
+                    "errno": "~0.1.1"
+                  }
+                },
+                "levelup": {
+                  "version": "1.3.9",
+                  "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
+                  "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
+                  "dev": true,
+                  "requires": {
+                    "deferred-leveldown": "~1.2.1",
+                    "level-codec": "~7.0.0",
+                    "level-errors": "~1.0.3",
+                    "level-iterator-stream": "~1.3.0",
+                    "prr": "~1.0.1",
+                    "semver": "~5.4.1",
+                    "xtend": "~4.0.0"
+                  }
+                }
+              }
+            },
+            "methods": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+              "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+              "dev": true
+            },
+            "miller-rabin": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+              "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "bn.js": "^4.0.0",
+                "brorand": "^1.0.1"
+              }
+            },
+            "mime": {
+              "version": "1.4.1",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+              "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+              "dev": true
+            },
+            "mime-db": {
+              "version": "1.37.0",
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+              "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
+              "dev": true
+            },
+            "mime-types": {
+              "version": "2.1.21",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
+              "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+              "dev": true,
+              "requires": {
+                "mime-db": "~1.37.0"
+              }
+            },
+            "mimic-response": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+              "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+              "dev": true
+            },
+            "min-document": {
+              "version": "2.19.0",
+              "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+              "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+              "dev": true,
+              "requires": {
+                "dom-walk": "^0.1.0"
+              }
+            },
+            "minimalistic-assert": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+              "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+            },
+            "minimalistic-crypto-utils": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+              "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "dev": true
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "dev": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "mkdirp-promise": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-5.0.1.tgz",
+              "integrity": "sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "mkdirp": "*"
+              }
+            },
+            "mock-fs": {
+              "version": "4.7.0",
+              "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.7.0.tgz",
+              "integrity": "sha512-WlQNtUlzMRpvLHf8dqeUmNqfdPjGY29KrJF50Ldb4AcL+vQeR8QH3wQcFMgrhTwb1gHjZn9xggho+84tBskLgA==",
+              "dev": true,
+              "optional": true
+            },
+            "mout": {
+              "version": "0.11.1",
+              "resolved": "https://registry.npmjs.org/mout/-/mout-0.11.1.tgz",
+              "integrity": "sha1-ujYR318OWx/7/QEWa48C0fX6K5k=",
+              "dev": true,
+              "optional": true
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            },
+            "mz": {
+              "version": "2.7.0",
+              "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+              "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "any-promise": "^1.0.0",
+                "object-assign": "^4.0.1",
+                "thenify-all": "^1.0.0"
+              }
+            },
+            "nan": {
+              "version": "2.10.0",
+              "resolved": "http://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+              "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+            },
+            "nano-json-stream-parser": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz",
+              "integrity": "sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18=",
+              "dev": true
+            },
+            "negotiator": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+              "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+              "dev": true
+            },
+            "node-fetch": {
+              "version": "2.1.2",
+              "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+              "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=",
+              "dev": true
+            },
+            "normalize-package-data": {
+              "version": "2.4.0",
+              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+              "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+              "dev": true,
+              "requires": {
+                "hosted-git-info": "^2.1.4",
+                "is-builtin-module": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+              "dev": true
+            },
+            "number-to-bn": {
+              "version": "1.7.0",
+              "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
+              "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
+              "dev": true,
+              "requires": {
+                "bn.js": "4.11.6",
+                "strip-hex-prefix": "1.0.0"
+              },
+              "dependencies": {
+                "bn.js": {
+                  "version": "4.11.6",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+                  "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+                  "dev": true
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.9.0",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+              "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+              "dev": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+              "dev": true
+            },
+            "object-inspect": {
+              "version": "1.6.0",
+              "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+              "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+              "dev": true
+            },
+            "object-keys": {
+              "version": "0.4.0",
+              "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+              "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
+              "dev": true
+            },
+            "oboe": {
+              "version": "2.1.3",
+              "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.3.tgz",
+              "integrity": "sha1-K0hl29Rr6BIlcT9Om/5Lz09oCk8=",
+              "dev": true,
+              "requires": {
+                "http-https": "^1.0.0"
+              }
+            },
+            "on-finished": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+              "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+              "dev": true,
+              "requires": {
+                "ee-first": "1.1.1"
+              }
+            },
+            "once": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+              "dev": true
+            },
+            "os-locale": {
+              "version": "1.4.0",
+              "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+              "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+              "dev": true,
+              "requires": {
+                "lcid": "^1.0.0"
+              }
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+              "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+              "dev": true
+            },
+            "p-cancelable": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+              "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
+              "dev": true
+            },
+            "p-finally": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+              "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+              "dev": true
+            },
+            "p-timeout": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
+              "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
+              "dev": true,
+              "requires": {
+                "p-finally": "^1.0.0"
+              }
+            },
+            "parse-asn1": {
+              "version": "5.1.1",
+              "resolved": "http://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
+              "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
+              "dev": true,
+              "requires": {
+                "asn1.js": "^4.0.0",
+                "browserify-aes": "^1.0.0",
+                "create-hash": "^1.1.0",
+                "evp_bytestokey": "^1.0.0",
+                "pbkdf2": "^3.0.3"
+              }
+            },
+            "parse-headers": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
+              "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
+              "dev": true,
+              "requires": {
+                "for-each": "^0.3.2",
+                "trim": "0.0.1"
+              }
+            },
+            "parse-json": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+              "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+              "dev": true,
+              "requires": {
+                "error-ex": "^1.2.0"
+              }
+            },
+            "parseurl": {
+              "version": "1.3.2",
+              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+              "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
+              "dev": true
+            },
+            "path-exists": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+              "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+              "dev": true,
+              "requires": {
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+            },
+            "path-parse": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+              "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+              "dev": true
+            },
+            "path-to-regexp": {
+              "version": "0.1.7",
+              "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+              "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+              "dev": true
+            },
+            "path-type": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+              "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              },
+              "dependencies": {
+                "pify": {
+                  "version": "2.3.0",
+                  "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                  "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                  "dev": true
+                }
+              }
+            },
+            "pbkdf2": {
+              "version": "3.0.17",
+              "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
+              "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+              "dev": true,
+              "requires": {
+                "create-hash": "^1.1.2",
+                "create-hmac": "^1.1.4",
+                "ripemd160": "^2.0.1",
+                "safe-buffer": "^5.0.1",
+                "sha.js": "^2.4.8"
+              }
+            },
+            "pend": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+              "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+              "dev": true,
+              "optional": true
+            },
+            "performance-now": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+              "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+              "dev": true
+            },
+            "pinkie": {
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+              "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+              "dev": true
+            },
+            "pinkie-promise": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+              "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+              "dev": true,
+              "requires": {
+                "pinkie": "^2.0.0"
+              }
+            },
+            "precond": {
+              "version": "0.2.3",
+              "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+              "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw=",
+              "dev": true
+            },
+            "prepend-http": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+              "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+              "dev": true
+            },
+            "private": {
+              "version": "0.1.8",
+              "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+              "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+              "dev": true
+            },
+            "process": {
+              "version": "0.5.2",
+              "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+              "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=",
+              "dev": true
+            },
+            "process-nextick-args": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+              "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+              "dev": true
+            },
+            "promise-to-callback": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/promise-to-callback/-/promise-to-callback-1.0.0.tgz",
+              "integrity": "sha1-XSp0kBC/tn2WNZj805YHRqaP7vc=",
+              "dev": true,
+              "requires": {
+                "is-fn": "^1.0.0",
+                "set-immediate-shim": "^1.0.1"
+              }
+            },
+            "proxy-addr": {
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
+              "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
+              "dev": true,
+              "requires": {
+                "forwarded": "~0.1.2",
+                "ipaddr.js": "1.8.0"
+              }
+            },
+            "prr": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+              "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+              "dev": true
+            },
+            "pseudomap": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+              "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+              "dev": true
+            },
+            "psl": {
+              "version": "1.1.29",
+              "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
+              "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
+              "dev": true
+            },
+            "public-encrypt": {
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+              "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "bn.js": "^4.1.0",
+                "browserify-rsa": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "parse-asn1": "^5.0.0",
+                "randombytes": "^2.0.1",
+                "safe-buffer": "^5.1.2"
+              }
+            },
+            "pull-cat": {
+              "version": "1.1.11",
+              "resolved": "https://registry.npmjs.org/pull-cat/-/pull-cat-1.1.11.tgz",
+              "integrity": "sha1-tkLdElXaN2pwa220+pYvX9t0wxs=",
+              "dev": true
+            },
+            "pull-defer": {
+              "version": "0.2.3",
+              "resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.3.tgz",
+              "integrity": "sha512-/An3KE7mVjZCqNhZsr22k1Tx8MACnUnHZZNPSJ0S62td8JtYr/AiRG42Vz7Syu31SoTLUzVIe61jtT/pNdjVYA==",
+              "dev": true
+            },
+            "pull-level": {
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.4.tgz",
+              "integrity": "sha512-fW6pljDeUThpq5KXwKbRG3X7Ogk3vc75d5OQU/TvXXui65ykm+Bn+fiktg+MOx2jJ85cd+sheufPL+rw9QSVZg==",
+              "dev": true,
+              "requires": {
+                "level-post": "^1.0.7",
+                "pull-cat": "^1.1.9",
+                "pull-live": "^1.0.1",
+                "pull-pushable": "^2.0.0",
+                "pull-stream": "^3.4.0",
+                "pull-window": "^2.1.4",
+                "stream-to-pull-stream": "^1.7.1"
+              }
+            },
+            "pull-live": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/pull-live/-/pull-live-1.0.1.tgz",
+              "integrity": "sha1-pOzuAeMwFV6RJLu89HYfIbOPUfU=",
+              "dev": true,
+              "requires": {
+                "pull-cat": "^1.1.9",
+                "pull-stream": "^3.4.0"
+              }
+            },
+            "pull-pushable": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.2.0.tgz",
+              "integrity": "sha1-Xy867UethpGfAbEqLpnW8b13ZYE=",
+              "dev": true
+            },
+            "pull-stream": {
+              "version": "3.6.9",
+              "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
+              "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw==",
+              "dev": true
+            },
+            "pull-window": {
+              "version": "2.1.4",
+              "resolved": "https://registry.npmjs.org/pull-window/-/pull-window-2.1.4.tgz",
+              "integrity": "sha1-/DuG/uvRkgx64pdpHiP3BfiFUvA=",
+              "dev": true,
+              "requires": {
+                "looper": "^2.0.0"
+              }
+            },
+            "punycode": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+              "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+              "dev": true
+            },
+            "qs": {
+              "version": "6.5.2",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+              "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+              "dev": true
+            },
+            "query-string": {
+              "version": "5.1.1",
+              "resolved": "http://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+              "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+              "dev": true,
+              "requires": {
+                "decode-uri-component": "^0.2.0",
+                "object-assign": "^4.1.0",
+                "strict-uri-encode": "^1.0.0"
+              }
+            },
+            "randombytes": {
+              "version": "2.0.6",
+              "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
+              "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
+              "dev": true,
+              "requires": {
+                "safe-buffer": "^5.1.0"
+              }
+            },
+            "randomfill": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+              "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "randombytes": "^2.0.5",
+                "safe-buffer": "^5.1.0"
+              }
+            },
+            "randomhex": {
+              "version": "0.1.5",
+              "resolved": "https://registry.npmjs.org/randomhex/-/randomhex-0.1.5.tgz",
+              "integrity": "sha1-us7vmCMpCRQA8qKRLGzQLxCU9YU=",
+              "dev": true
+            },
+            "range-parser": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+              "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+              "dev": true
+            },
+            "raw-body": {
+              "version": "2.3.3",
+              "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+              "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+              "dev": true,
+              "requires": {
+                "bytes": "3.0.0",
+                "http-errors": "1.6.3",
+                "iconv-lite": "0.4.23",
+                "unpipe": "1.0.0"
+              }
+            },
+            "read-pkg": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+              "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+              "dev": true,
+              "requires": {
+                "load-json-file": "^1.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^1.0.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+              "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+              "dev": true,
+              "requires": {
+                "find-up": "^1.0.0",
+                "read-pkg": "^1.0.0"
+              }
+            },
+            "readable-stream": {
+              "version": "2.3.6",
+              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              },
+              "dependencies": {
+                "isarray": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                  "dev": true
+                },
+                "string_decoder": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                  "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                  "dev": true,
+                  "requires": {
+                    "safe-buffer": "~5.1.0"
+                  }
+                }
+              }
+            },
+            "regenerate": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+              "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+              "dev": true
+            },
+            "regenerator-runtime": {
+              "version": "0.11.1",
+              "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+              "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+              "dev": true
+            },
+            "regenerator-transform": {
+              "version": "0.10.1",
+              "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
+              "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+              "dev": true,
+              "requires": {
+                "babel-runtime": "^6.18.0",
+                "babel-types": "^6.19.0",
+                "private": "^0.1.6"
+              }
+            },
+            "regexpu-core": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+              "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+              "dev": true,
+              "requires": {
+                "regenerate": "^1.2.1",
+                "regjsgen": "^0.2.0",
+                "regjsparser": "^0.1.4"
+              }
+            },
+            "regjsgen": {
+              "version": "0.2.0",
+              "resolved": "http://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+              "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+              "dev": true
+            },
+            "regjsparser": {
+              "version": "0.1.5",
+              "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+              "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+              "dev": true,
+              "requires": {
+                "jsesc": "~0.5.0"
+              }
+            },
+            "repeating": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+              "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+              "dev": true,
+              "requires": {
+                "is-finite": "^1.0.0"
+              }
+            },
+            "request": {
+              "version": "2.88.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+              "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+              "dev": true,
+              "requires": {
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.0",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.4.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.3.2"
+              }
+            },
+            "require-directory": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+              "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+              "dev": true
+            },
+            "require-from-string": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
+              "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
+              "dev": true
+            },
+            "require-main-filename": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+              "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+              "dev": true
+            },
+            "resolve": {
+              "version": "1.7.1",
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
+              "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+              "dev": true,
+              "requires": {
+                "path-parse": "^1.0.5"
+              }
+            },
+            "resumer": {
+              "version": "0.0.0",
+              "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+              "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+              "dev": true,
+              "requires": {
+                "through": "~2.3.4"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.2",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+              "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+              "requires": {
+                "glob": "^7.0.5"
+              }
+            },
+            "ripemd160": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+              "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+              "requires": {
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1"
+              }
+            },
+            "rlp": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.1.0.tgz",
+              "integrity": "sha512-93U7IKH5j7nmXFVg19MeNBGzQW5uXW1pmCuKY8veeKIhYTE32C2d0mOegfiIAfXcHOKJjjPlJisn8iHDF5AezA==",
+              "requires": {
+                "safe-buffer": "^5.1.1"
+              }
+            },
+            "rustbn.js": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.2.0.tgz",
+              "integrity": "sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA==",
+              "dev": true
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            },
+            "safe-event-emitter": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/safe-event-emitter/-/safe-event-emitter-1.0.1.tgz",
+              "integrity": "sha512-e1wFe99A91XYYxoQbcq2ZJUWurxEyP8vfz7A7vuUe1s95q8r5ebraVaA1BukYJcpM6V16ugWoD9vngi8Ccu5fg==",
+              "dev": true,
+              "requires": {
+                "events": "^3.0.0"
+              }
+            },
+            "safer-buffer": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+              "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+              "dev": true
+            },
+            "scrypt": {
+              "version": "6.0.3",
+              "resolved": "https://registry.npmjs.org/scrypt/-/scrypt-6.0.3.tgz",
+              "integrity": "sha1-BOAUpWgrU/pQwtXM4WfXGcBthw0=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "nan": "^2.0.8"
+              }
+            },
+            "scrypt.js": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/scrypt.js/-/scrypt.js-0.2.0.tgz",
+              "integrity": "sha1-r40UZbcemZARC+38WTuUeeA6ito=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "scrypt": "^6.0.2",
+                "scryptsy": "^1.2.1"
+              }
+            },
+            "scryptsy": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-1.2.1.tgz",
+              "integrity": "sha1-oyJfpLJST4AnAHYeKFW987LZIWM=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "pbkdf2": "^3.0.3"
+              }
+            },
+            "secp256k1": {
+              "version": "3.5.2",
+              "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.2.tgz",
+              "integrity": "sha512-iin3kojdybY6NArd+UFsoTuapOF7bnJNf2UbcWXaY3z+E1sJDipl60vtzB5hbO/uquBu7z0fd4VC4Irp+xoFVQ==",
+              "requires": {
+                "bindings": "^1.2.1",
+                "bip66": "^1.1.3",
+                "bn.js": "^4.11.3",
+                "create-hash": "^1.1.2",
+                "drbg.js": "^1.0.1",
+                "elliptic": "^6.2.3",
+                "nan": "^2.2.1",
+                "safe-buffer": "^5.1.0"
+              }
+            },
+            "seedrandom": {
+              "version": "2.4.4",
+              "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-2.4.4.tgz",
+              "integrity": "sha512-9A+PDmgm+2du77B5i0Ip2cxOqqHjgNxnBgglxLcX78A2D6c2rTo61z4jnVABpF4cKeDMDG+cmXXvdnqse2VqMA==",
+              "dev": true
+            },
+            "seek-bzip": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
+              "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "commander": "~2.8.1"
+              }
+            },
+            "semaphore": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.1.0.tgz",
+              "integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA==",
+              "dev": true
+            },
+            "semver": {
+              "version": "5.4.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+              "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+              "dev": true
+            },
+            "send": {
+              "version": "0.16.2",
+              "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+              "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+              "dev": true,
+              "requires": {
+                "debug": "2.6.9",
+                "depd": "~1.1.2",
+                "destroy": "~1.0.4",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
+                "fresh": "0.5.2",
+                "http-errors": "~1.6.2",
+                "mime": "1.4.1",
+                "ms": "2.0.0",
+                "on-finished": "~2.3.0",
+                "range-parser": "~1.2.0",
+                "statuses": "~1.4.0"
+              },
+              "dependencies": {
+                "debug": {
+                  "version": "2.6.9",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                  "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                  "dev": true,
+                  "requires": {
+                    "ms": "2.0.0"
+                  }
+                },
+                "statuses": {
+                  "version": "1.4.0",
+                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+                  "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+                  "dev": true
+                }
+              }
+            },
+            "serve-static": {
+              "version": "1.13.2",
+              "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+              "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+              "dev": true,
+              "requires": {
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "parseurl": "~1.3.2",
+                "send": "0.16.2"
+              }
+            },
+            "servify": {
+              "version": "0.1.12",
+              "resolved": "https://registry.npmjs.org/servify/-/servify-0.1.12.tgz",
+              "integrity": "sha512-/xE6GvsKKqyo1BAY+KxOWXcLpPsUUyji7Qg3bVD7hh1eRze5bR1uYiuDA/k3Gof1s9BTzQZEJK8sNcNGFIzeWw==",
+              "dev": true,
+              "requires": {
+                "body-parser": "^1.16.0",
+                "cors": "^2.8.1",
+                "express": "^4.14.0",
+                "request": "^2.79.0",
+                "xhr": "^2.3.3"
+              }
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+              "dev": true
+            },
+            "set-immediate-shim": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+              "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+              "dev": true
+            },
+            "setimmediate": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+              "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+              "dev": true,
+              "optional": true
+            },
+            "setprototypeof": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+              "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+              "dev": true
+            },
+            "sha.js": {
+              "version": "2.4.11",
+              "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+              "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+              "requires": {
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+              }
+            },
+            "sha3": {
+              "version": "1.2.2",
+              "resolved": "https://registry.npmjs.org/sha3/-/sha3-1.2.2.tgz",
+              "integrity": "sha1-pmxQmN5MJbyIM27ItIF9AFvKe6k=",
+              "dev": true,
+              "requires": {
+                "nan": "2.10.0"
+              }
+            },
+            "simple-concat": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
+              "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
+              "dev": true
+            },
+            "simple-get": {
+              "version": "2.8.1",
+              "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
+              "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
+              "dev": true,
+              "requires": {
+                "decompress-response": "^3.3.0",
+                "once": "^1.3.1",
+                "simple-concat": "^1.0.0"
+              }
+            },
+            "slash": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+              "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+              "dev": true
+            },
+            "solc": {
+              "version": "0.4.24",
+              "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.24.tgz",
+              "integrity": "sha512-2xd7Cf1HeVwrIb6Bu1cwY2/TaLRodrppCq3l7rhLimFQgmxptXhTC3+/wesVLpB09F1A2kZgvbMOgH7wvhFnBQ==",
+              "dev": true,
+              "requires": {
+                "fs-extra": "^0.30.0",
+                "memorystream": "^0.3.1",
+                "require-from-string": "^1.1.0",
+                "semver": "^5.3.0",
+                "yargs": "^4.7.1"
+              },
+              "dependencies": {
+                "fs-extra": {
+                  "version": "0.30.0",
+                  "resolved": "http://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+                  "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+                  "dev": true,
+                  "requires": {
+                    "graceful-fs": "^4.1.2",
+                    "jsonfile": "^2.1.0",
+                    "klaw": "^1.0.0",
+                    "path-is-absolute": "^1.0.0",
+                    "rimraf": "^2.2.8"
+                  }
+                }
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "dev": true
+            },
+            "spdx-correct": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
+              "integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
+              "dev": true,
+              "requires": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+              }
+            },
+            "spdx-exceptions": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+              "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+              "dev": true
+            },
+            "spdx-expression-parse": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+              "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+              "dev": true,
+              "requires": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+              }
+            },
+            "spdx-license-ids": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz",
+              "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg==",
+              "dev": true
+            },
+            "sshpk": {
+              "version": "1.15.2",
+              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
+              "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
+              "dev": true,
+              "requires": {
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
+              }
+            },
+            "statuses": {
+              "version": "1.5.0",
+              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+              "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+              "dev": true
+            },
+            "stream-to-pull-stream": {
+              "version": "1.7.2",
+              "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.2.tgz",
+              "integrity": "sha1-dXYJrhzr0zx0MtSvvjH/eGULnd4=",
+              "dev": true,
+              "requires": {
+                "looper": "^3.0.0",
+                "pull-stream": "^3.2.3"
+              },
+              "dependencies": {
+                "looper": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
+                  "integrity": "sha1-LvpUw7HLq6m5Su4uWRSwvlf7t0k=",
+                  "dev": true
+                }
+              }
+            },
+            "strict-uri-encode": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+              "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+              "dev": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "string.prototype.trim": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+              "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+              "dev": true,
+              "requires": {
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.5.0",
+                "function-bind": "^1.0.2"
+              }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "strip-bom": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+              "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+              "dev": true,
+              "requires": {
+                "is-utf8": "^0.2.0"
+              }
+            },
+            "strip-dirs": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
+              "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "is-natural-number": "^4.0.1"
+              }
+            },
+            "strip-hex-prefix": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
+              "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
+              "requires": {
+                "is-hex-prefixed": "1.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
+            },
+            "swarm-js": {
+              "version": "0.1.37",
+              "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.37.tgz",
+              "integrity": "sha512-G8gi5fcXP/2upwiuOShJ258sIufBVztekgobr3cVgYXObZwJ5AXLqZn52AI+/ffft29pJexF9WNdUxjlkVehoQ==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "bluebird": "^3.5.0",
+                "buffer": "^5.0.5",
+                "decompress": "^4.0.0",
+                "eth-lib": "^0.1.26",
+                "fs-extra": "^2.1.2",
+                "fs-promise": "^2.0.0",
+                "got": "^7.1.0",
+                "mime-types": "^2.1.16",
+                "mkdirp-promise": "^5.0.1",
+                "mock-fs": "^4.1.0",
+                "setimmediate": "^1.0.5",
+                "tar.gz": "^1.0.5",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "tape": {
+              "version": "4.9.1",
+              "resolved": "https://registry.npmjs.org/tape/-/tape-4.9.1.tgz",
+              "integrity": "sha512-6fKIXknLpoe/Jp4rzHKFPpJUHDHDqn8jus99IfPnHIjyz78HYlefTGD3b5EkbQzuLfaEvmfPK3IolLgq2xT3kw==",
+              "dev": true,
+              "requires": {
+                "deep-equal": "~1.0.1",
+                "defined": "~1.0.0",
+                "for-each": "~0.3.3",
+                "function-bind": "~1.1.1",
+                "glob": "~7.1.2",
+                "has": "~1.0.3",
+                "inherits": "~2.0.3",
+                "minimist": "~1.2.0",
+                "object-inspect": "~1.6.0",
+                "resolve": "~1.7.1",
+                "resumer": "~0.0.0",
+                "string.prototype.trim": "~1.1.2",
+                "through": "~2.3.8"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "1.2.0",
+                  "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                  "dev": true
+                }
+              }
+            },
+            "tar": {
+              "version": "2.2.1",
+              "resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+              "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
+              }
+            },
+            "tar-stream": {
+              "version": "1.6.2",
+              "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+              "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+              "dev": true,
+              "requires": {
+                "bl": "^1.0.0",
+                "buffer-alloc": "^1.2.0",
+                "end-of-stream": "^1.0.0",
+                "fs-constants": "^1.0.0",
+                "readable-stream": "^2.3.0",
+                "to-buffer": "^1.1.1",
+                "xtend": "^4.0.0"
+              }
+            },
+            "tar.gz": {
+              "version": "1.0.7",
+              "resolved": "https://registry.npmjs.org/tar.gz/-/tar.gz-1.0.7.tgz",
+              "integrity": "sha512-uhGatJvds/3diZrETqMj4RxBR779LKlIE74SsMcn5JProZsfs9j0QBwWO1RW+IWNJxS2x8Zzra1+AW6OQHWphg==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "bluebird": "^2.9.34",
+                "commander": "^2.8.1",
+                "fstream": "^1.0.8",
+                "mout": "^0.11.0",
+                "tar": "^2.1.1"
+              },
+              "dependencies": {
+                "bluebird": {
+                  "version": "2.11.0",
+                  "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+                  "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            },
+            "thenify": {
+              "version": "3.3.0",
+              "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
+              "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+              "dev": true,
+              "requires": {
+                "any-promise": "^1.0.0"
+              }
+            },
+            "thenify-all": {
+              "version": "1.6.0",
+              "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+              "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+              "dev": true,
+              "requires": {
+                "thenify": ">= 3.1.0 < 4"
+              }
+            },
+            "through": {
+              "version": "2.3.8",
+              "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+              "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+              "dev": true
+            },
+            "through2": {
+              "version": "2.0.5",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+              "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+              "dev": true,
+              "requires": {
+                "readable-stream": "~2.3.6",
+                "xtend": "~4.0.1"
+              }
+            },
+            "timed-out": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+              "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+              "dev": true
+            },
+            "tmp": {
+              "version": "0.0.33",
+              "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+              "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+              "dev": true,
+              "requires": {
+                "os-tmpdir": "~1.0.2"
+              }
+            },
+            "to-buffer": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+              "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
+              "dev": true
+            },
+            "to-fast-properties": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+              "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+              "dev": true
+            },
+            "tough-cookie": {
+              "version": "2.4.3",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+              "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+              "dev": true,
+              "requires": {
+                "psl": "^1.1.24",
+                "punycode": "^1.4.1"
+              },
+              "dependencies": {
+                "punycode": {
+                  "version": "1.4.1",
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                  "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+                  "dev": true
+                }
+              }
+            },
+            "treeify": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
+              "integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==",
+              "dev": true
+            },
+            "trim": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+              "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
+              "dev": true
+            },
+            "trim-right": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+              "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+              "dev": true
+            },
+            "tunnel-agent": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+              "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+              "dev": true,
+              "requires": {
+                "safe-buffer": "^5.0.1"
+              }
+            },
+            "tweetnacl": {
+              "version": "0.14.5",
+              "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+              "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+              "dev": true
+            },
+            "type-is": {
+              "version": "1.6.16",
+              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+              "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+              "dev": true,
+              "requires": {
+                "media-typer": "0.3.0",
+                "mime-types": "~2.1.18"
+              }
+            },
+            "typedarray": {
+              "version": "0.0.6",
+              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+              "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+              "dev": true
+            },
+            "typedarray-to-buffer": {
+              "version": "3.1.5",
+              "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+              "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+              "requires": {
+                "is-typedarray": "^1.0.0"
+              }
+            },
+            "typewise": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
+              "integrity": "sha1-EGeTZUCvl5N8xdz5kiSG6fooRlE=",
+              "dev": true,
+              "requires": {
+                "typewise-core": "^1.2.0"
+              }
+            },
+            "typewise-core": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
+              "integrity": "sha1-l+uRgFx/VdL5QXSPpQ0xXZke8ZU=",
+              "dev": true
+            },
+            "typewiselite": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/typewiselite/-/typewiselite-1.0.0.tgz",
+              "integrity": "sha1-yIgvobsQksBgBal/NO9chQjjZk4=",
+              "dev": true
+            },
+            "ultron": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+              "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+              "dev": true
+            },
+            "unbzip2-stream": {
+              "version": "1.3.1",
+              "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.1.tgz",
+              "integrity": "sha512-fIZnvdjblYs7Cru/xC6tCPVhz7JkYcVQQkePwMLyQELzYTds2Xn8QefPVnvdVhhZqubxNA1cASXEH5wcK0Bucw==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "buffer": "^3.0.1",
+                "through": "^2.3.6"
+              },
+              "dependencies": {
+                "base64-js": {
+                  "version": "0.0.8",
+                  "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+                  "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg=",
+                  "dev": true,
+                  "optional": true
+                },
+                "buffer": {
+                  "version": "3.6.0",
+                  "resolved": "http://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+                  "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "base64-js": "0.0.8",
+                    "ieee754": "^1.1.4",
+                    "isarray": "^1.0.0"
+                  }
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            },
+            "underscore": {
+              "version": "1.8.3",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+              "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+              "dev": true
+            },
+            "unorm": {
+              "version": "1.4.1",
+              "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.4.1.tgz",
+              "integrity": "sha1-NkIA1fE2RsqLzURJAnEzVhR5IwA=",
+              "dev": true
+            },
+            "unpipe": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+              "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+              "dev": true
+            },
+            "uri-js": {
+              "version": "4.2.2",
+              "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+              "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+              "dev": true,
+              "requires": {
+                "punycode": "^2.1.0"
+              }
+            },
+            "url-parse-lax": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+              "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+              "dev": true,
+              "requires": {
+                "prepend-http": "^1.0.1"
+              }
+            },
+            "url-set-query": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
+              "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk=",
+              "dev": true
+            },
+            "url-to-options": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
+              "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
+              "dev": true
+            },
+            "utf8": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+              "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
+              "dev": true,
+              "optional": true
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+              "dev": true
+            },
+            "utils-merge": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+              "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+              "dev": true
+            },
+            "uuid": {
+              "version": "3.3.2",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+              "dev": true
+            },
+            "validate-npm-package-license": {
+              "version": "3.0.4",
+              "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+              "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+              "dev": true,
+              "requires": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+              }
+            },
+            "vary": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+              "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+              "dev": true
+            },
+            "verror": {
+              "version": "1.10.0",
+              "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+              "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+              "dev": true,
+              "requires": {
+                "assert-plus": "^1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "^1.2.0"
+              }
+            },
+            "web3": {
+              "version": "1.0.0-beta.35",
+              "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.35.tgz",
+              "integrity": "sha512-xwDmUhvTcHQvvNnOPcPZZgCxKUsI2e+GbHy7JkTK3/Rmnutazy8x7fsAXT9myw7V1qpi3GgLoZ3fkglSUbg1Mg==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "web3-bzz": "1.0.0-beta.35",
+                "web3-core": "1.0.0-beta.35",
+                "web3-eth": "1.0.0-beta.35",
+                "web3-eth-personal": "1.0.0-beta.35",
+                "web3-net": "1.0.0-beta.35",
+                "web3-shh": "1.0.0-beta.35",
+                "web3-utils": "1.0.0-beta.35"
+              }
+            },
+            "web3-bzz": {
+              "version": "1.0.0-beta.35",
+              "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.35.tgz",
+              "integrity": "sha512-BhAU0qhlr8zltm4gs/+P1gki2VkxHJaM2Rrh4DGesDW0lzwufRoNvWFlwx1bKHoFPWNbSmm9PRkHOYOINL/Tgw==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "got": "7.1.0",
+                "swarm-js": "0.1.37",
+                "underscore": "1.8.3"
+              }
+            },
+            "web3-core": {
+              "version": "1.0.0-beta.35",
+              "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.35.tgz",
+              "integrity": "sha512-ayGavbgVk4KL9Y88Uv411fBJ0SVgVfKhKEBweKYzmP0zOqneMzWt6YsyD1n6kRvjAbqA0AfUPEOKyMNjcx2tjw==",
+              "dev": true,
+              "requires": {
+                "web3-core-helpers": "1.0.0-beta.35",
+                "web3-core-method": "1.0.0-beta.35",
+                "web3-core-requestmanager": "1.0.0-beta.35",
+                "web3-utils": "1.0.0-beta.35"
+              }
+            },
+            "web3-core-helpers": {
+              "version": "1.0.0-beta.35",
+              "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.35.tgz",
+              "integrity": "sha512-APOu3sEsamyqWt//8o4yq9KF25/uqGm+pQShson/sC4gKzmfJB07fLo2ond0X30E8fIqAPeVCotPXQxGciGUmA==",
+              "dev": true,
+              "requires": {
+                "underscore": "1.8.3",
+                "web3-eth-iban": "1.0.0-beta.35",
+                "web3-utils": "1.0.0-beta.35"
+              }
+            },
+            "web3-core-method": {
+              "version": "1.0.0-beta.35",
+              "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.35.tgz",
+              "integrity": "sha512-jidImCide8q0GpfsO4L73qoHrbkeWgwU3uOH5DKtJtv0ccmG086knNMRgryb/o9ZgetDWLmDEsJnHjBSoIwcbA==",
+              "dev": true,
+              "requires": {
+                "underscore": "1.8.3",
+                "web3-core-helpers": "1.0.0-beta.35",
+                "web3-core-promievent": "1.0.0-beta.35",
+                "web3-core-subscriptions": "1.0.0-beta.35",
+                "web3-utils": "1.0.0-beta.35"
+              }
+            },
+            "web3-core-promievent": {
+              "version": "1.0.0-beta.35",
+              "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.35.tgz",
+              "integrity": "sha512-GvqXqKq07OmHuVi5uNRg6k79a1/CI0ViCC+EtNv4CORHtDRmYEt5Bvdv6z6FJEiaaQkD0lKbFwNhLxutx7HItw==",
+              "dev": true,
+              "requires": {
+                "any-promise": "1.3.0",
+                "eventemitter3": "1.1.1"
+              }
+            },
+            "web3-core-requestmanager": {
+              "version": "1.0.0-beta.35",
+              "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.35.tgz",
+              "integrity": "sha512-S+zW2h17ZZQU9oe3yaCJE0E7aJS4C3Kf4kGPDv+nXjW0gKhQQhgVhw1Doq/aYQGqNSWJp7f1VHkz5gQWwg6RRg==",
+              "dev": true,
+              "requires": {
+                "underscore": "1.8.3",
+                "web3-core-helpers": "1.0.0-beta.35",
+                "web3-providers-http": "1.0.0-beta.35",
+                "web3-providers-ipc": "1.0.0-beta.35",
+                "web3-providers-ws": "1.0.0-beta.35"
+              }
+            },
+            "web3-core-subscriptions": {
+              "version": "1.0.0-beta.35",
+              "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.35.tgz",
+              "integrity": "sha512-gXzLrWvcGkGiWq1y33Z4Y80XI8XMrwowiQJkrPSjQ81K5PBKquOGwcMffLaKcwdmEy/NpsOXDeFo3eLE1Ghvvw==",
+              "dev": true,
+              "requires": {
+                "eventemitter3": "1.1.1",
+                "underscore": "1.8.3",
+                "web3-core-helpers": "1.0.0-beta.35"
+              }
+            },
+            "web3-eth": {
+              "version": "1.0.0-beta.35",
+              "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.35.tgz",
+              "integrity": "sha512-04mcb2nGPXThawuuYICPOxv0xOHofvQKsjZeIq+89nyOC8DQMGTAErDkGyMHQYtjpth5XDhic0wuEsA80AmFZA==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "underscore": "1.8.3",
+                "web3-core": "1.0.0-beta.35",
+                "web3-core-helpers": "1.0.0-beta.35",
+                "web3-core-method": "1.0.0-beta.35",
+                "web3-core-subscriptions": "1.0.0-beta.35",
+                "web3-eth-abi": "1.0.0-beta.35",
+                "web3-eth-accounts": "1.0.0-beta.35",
+                "web3-eth-contract": "1.0.0-beta.35",
+                "web3-eth-iban": "1.0.0-beta.35",
+                "web3-eth-personal": "1.0.0-beta.35",
+                "web3-net": "1.0.0-beta.35",
+                "web3-utils": "1.0.0-beta.35"
+              }
+            },
+            "web3-eth-abi": {
+              "version": "1.0.0-beta.35",
+              "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.35.tgz",
+              "integrity": "sha512-KUDC+EtFFYG8z01ZleKrASdjj327/rtWHzEt6RWsEj7bBa0bGp9nEh+nqdZx/Sdgz1O8tnfFzJlrRcXpfr1vGg==",
+              "dev": true,
+              "requires": {
+                "bn.js": "4.11.6",
+                "underscore": "1.8.3",
+                "web3-core-helpers": "1.0.0-beta.35",
+                "web3-utils": "1.0.0-beta.35"
+              },
+              "dependencies": {
+                "bn.js": {
+                  "version": "4.11.6",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+                  "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+                  "dev": true
+                }
+              }
+            },
+            "web3-eth-accounts": {
+              "version": "1.0.0-beta.35",
+              "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.35.tgz",
+              "integrity": "sha512-duIgRsfht/0kAW/eQ0X9lKtVIykbETrnM2H7EnvplCzPHtQLodpib4o9JXfh9n6ZDgdDC7cuJoiVB9QJg089ew==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "any-promise": "1.3.0",
+                "crypto-browserify": "3.12.0",
+                "eth-lib": "0.2.7",
+                "scrypt.js": "0.2.0",
+                "underscore": "1.8.3",
+                "uuid": "2.0.1",
+                "web3-core": "1.0.0-beta.35",
+                "web3-core-helpers": "1.0.0-beta.35",
+                "web3-core-method": "1.0.0-beta.35",
+                "web3-utils": "1.0.0-beta.35"
+              },
+              "dependencies": {
+                "eth-lib": {
+                  "version": "0.2.7",
+                  "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+                  "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "bn.js": "^4.11.6",
+                    "elliptic": "^6.4.0",
+                    "xhr-request-promise": "^0.1.2"
+                  }
+                },
+                "uuid": {
+                  "version": "2.0.1",
+                  "resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+                  "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            },
+            "web3-eth-contract": {
+              "version": "1.0.0-beta.35",
+              "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.35.tgz",
+              "integrity": "sha512-foPohOg5O1UCGKGZOIs+kQK5IZdV2QQ7pAWwNxH8WHplUA+fre1MurXNpoxknUmH6mYplFhXjqgYq2MsrBpHrA==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "underscore": "1.8.3",
+                "web3-core": "1.0.0-beta.35",
+                "web3-core-helpers": "1.0.0-beta.35",
+                "web3-core-method": "1.0.0-beta.35",
+                "web3-core-promievent": "1.0.0-beta.35",
+                "web3-core-subscriptions": "1.0.0-beta.35",
+                "web3-eth-abi": "1.0.0-beta.35",
+                "web3-utils": "1.0.0-beta.35"
+              }
+            },
+            "web3-eth-iban": {
+              "version": "1.0.0-beta.35",
+              "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.35.tgz",
+              "integrity": "sha512-H5wkcNcAIc+h/WoDIKv7ZYmrM2Xqu3O7jBQl1IWo73EDVQji+AoB2i3J8tuwI1yZRInRwrfpI3Zuwuf54hXHmQ==",
+              "dev": true,
+              "requires": {
+                "bn.js": "4.11.6",
+                "web3-utils": "1.0.0-beta.35"
+              },
+              "dependencies": {
+                "bn.js": {
+                  "version": "4.11.6",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+                  "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+                  "dev": true
+                }
+              }
+            },
+            "web3-eth-personal": {
+              "version": "1.0.0-beta.35",
+              "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.35.tgz",
+              "integrity": "sha512-AcM9nnlxu7ZRRxPvkrFB9eLxMM4A2cPfj2aCg21Wb2EpMnhR+b/O1cT33k7ApRowoMpM+T9M8vx2oPNwXfaCOQ==",
+              "dev": true,
+              "requires": {
+                "web3-core": "1.0.0-beta.35",
+                "web3-core-helpers": "1.0.0-beta.35",
+                "web3-core-method": "1.0.0-beta.35",
+                "web3-net": "1.0.0-beta.35",
+                "web3-utils": "1.0.0-beta.35"
+              }
+            },
+            "web3-net": {
+              "version": "1.0.0-beta.35",
+              "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.35.tgz",
+              "integrity": "sha512-bbwaQ/KohGjIJ6HAKbZ6KrklCAaG6/B7hIbAbVLSFLxF+Yz9lmAgQYaDInpidpC/NLb3WOmcbRF+P77J4qMVIA==",
+              "dev": true,
+              "requires": {
+                "web3-core": "1.0.0-beta.35",
+                "web3-core-method": "1.0.0-beta.35",
+                "web3-utils": "1.0.0-beta.35"
+              }
+            },
+            "web3-provider-engine": {
+              "version": "14.1.0",
+              "resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-14.1.0.tgz",
+              "integrity": "sha512-vGZtqhSUzGTiMGhJXNnB/aRDlrPZLhLnBZ2NPArkZtr8XSrwg9m08tw4+PuWg5za0TJuoE/vuPQc501HddZZWw==",
+              "dev": true,
+              "requires": {
+                "async": "^2.5.0",
+                "backoff": "^2.5.0",
+                "clone": "^2.0.0",
+                "cross-fetch": "^2.1.0",
+                "eth-block-tracker": "^3.0.0",
+                "eth-json-rpc-infura": "^3.1.0",
+                "eth-sig-util": "^1.4.2",
+                "ethereumjs-block": "^1.2.2",
+                "ethereumjs-tx": "^1.2.0",
+                "ethereumjs-util": "^5.1.5",
+                "ethereumjs-vm": "^2.3.4",
+                "json-rpc-error": "^2.0.0",
+                "json-stable-stringify": "^1.0.1",
+                "promise-to-callback": "^1.0.0",
+                "readable-stream": "^2.2.9",
+                "request": "^2.85.0",
+                "semaphore": "^1.0.3",
+                "ws": "^5.1.1",
+                "xhr": "^2.2.0",
+                "xtend": "^4.0.1"
+              },
+              "dependencies": {
+                "eth-sig-util": {
+                  "version": "1.4.2",
+                  "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
+                  "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
+                  "dev": true,
+                  "requires": {
+                    "ethereumjs-util": "^5.1.1"
+                  },
+                  "dependencies": {
+                    "ethereumjs-abi": {
+                      "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+                      "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+                      "requires": {
+                        "bn.js": "^4.10.0",
+                        "ethereumjs-util": "^5.0.0"
+                      }
+                    }
+                  }
+                },
+                "ethereumjs-abi": {
+                  "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+                  "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+                  "requires": {
+                    "bn.js": "^4.10.0",
+                    "ethereumjs-util": "^5.0.0"
+                  }
+                },
+                "ws": {
+                  "version": "5.2.2",
+                  "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+                  "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+                  "dev": true,
+                  "requires": {
+                    "async-limiter": "~1.0.0"
+                  }
+                }
+              }
+            },
+            "web3-providers-http": {
+              "version": "1.0.0-beta.35",
+              "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.35.tgz",
+              "integrity": "sha512-DcIMFq52Fb08UpWyZ3ZlES6NsNqJnco4hBS/Ej6eOcASfuUayPI+GLkYVZsnF3cBYqlH+DOKuArcKSuIxK7jIA==",
+              "dev": true,
+              "requires": {
+                "web3-core-helpers": "1.0.0-beta.35",
+                "xhr2-cookies": "1.1.0"
+              }
+            },
+            "web3-providers-ipc": {
+              "version": "1.0.0-beta.35",
+              "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.35.tgz",
+              "integrity": "sha512-iB0FG0HcpUnayfa8pn4guqEQ4Y1nrroi/jffdtQgFkrNt0sD3fMSwwC0AbmECqj3tDLl0e1slBR0RENll+ZF0g==",
+              "dev": true,
+              "requires": {
+                "oboe": "2.1.3",
+                "underscore": "1.8.3",
+                "web3-core-helpers": "1.0.0-beta.35"
+              }
+            },
+            "web3-providers-ws": {
+              "version": "1.0.0-beta.35",
+              "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.35.tgz",
+              "integrity": "sha512-Cx64NgDStynKaUGDIIOfaCd0fZusL8h5avKTkdTjUu2aHhFJhZoVBGVLhoDtUaqZGWIZGcBJOoVf2JkGUOjDRQ==",
+              "dev": true,
+              "requires": {
+                "underscore": "1.8.3",
+                "web3-core-helpers": "1.0.0-beta.35"
+              },
+              "dependencies": {
+                "debug": {
+                  "version": "2.6.9",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                  "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                  "requires": {
+                    "ms": "2.0.0"
+                  }
+                },
+                "websocket": {
+                  "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+                  "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+                  "requires": {
+                    "debug": "^2.2.0",
+                    "nan": "^2.3.3",
+                    "typedarray-to-buffer": "^3.1.2",
+                    "yaeti": "^0.0.6"
+                  }
+                }
+              }
+            },
+            "web3-shh": {
+              "version": "1.0.0-beta.35",
+              "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.35.tgz",
+              "integrity": "sha512-8qSonk/x0xabERS9Sr6AIADN/Ty+5KwARkkGIfSYHKqFpdMDz+76F7cUCxtoCZoS8K04xgZlDKYe0TJXLYA0Fw==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "web3-core": "1.0.0-beta.35",
+                "web3-core-method": "1.0.0-beta.35",
+                "web3-core-subscriptions": "1.0.0-beta.35",
+                "web3-net": "1.0.0-beta.35"
+              }
+            },
+            "web3-utils": {
+              "version": "1.0.0-beta.35",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.35.tgz",
+              "integrity": "sha512-Dq6f0SOKj3BDFRgOPnE6ALbzBDCKVIW8mKWVf7tGVhTDHf+wQaWwQSC3aArFSqdExB75BPBPyDpuMTNszhljpA==",
+              "dev": true,
+              "requires": {
+                "bn.js": "4.11.6",
+                "eth-lib": "0.1.27",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randomhex": "0.1.5",
+                "underscore": "1.8.3",
+                "utf8": "2.1.1"
+              },
+              "dependencies": {
+                "bn.js": {
+                  "version": "4.11.6",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+                  "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+                  "dev": true
+                },
+                "utf8": {
+                  "version": "2.1.1",
+                  "resolved": "http://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
+                  "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g=",
+                  "dev": true
+                }
+              }
+            },
+            "websocket": {
+              "version": "1.0.26",
+              "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.26.tgz",
+              "integrity": "sha512-fjcrYDPIQxpTnqFQ9JjxUQcdvR89MFAOjPBlF+vjOt49w/XW4fJknUoMz/mDIn2eK1AdslVojcaOxOqyZZV8rw==",
+              "dev": true,
+              "requires": {
+                "debug": "^2.2.0",
+                "nan": "^2.3.3",
+                "typedarray-to-buffer": "^3.1.2",
+                "yaeti": "^0.0.6"
+              },
+              "dependencies": {
+                "debug": {
+                  "version": "2.6.9",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                  "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                  "dev": true,
+                  "requires": {
+                    "ms": "2.0.0"
+                  }
+                }
+              }
+            },
+            "whatwg-fetch": {
+              "version": "2.0.4",
+              "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+              "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
+              "dev": true
+            },
+            "which-module": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+              "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+              "dev": true
+            },
+            "window-size": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+              "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
+              "dev": true
+            },
+            "wrap-ansi": {
+              "version": "2.1.0",
+              "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+              "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+              "dev": true,
+              "requires": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+            },
+            "ws": {
+              "version": "3.3.3",
+              "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+              "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+              "dev": true,
+              "requires": {
+                "async-limiter": "~1.0.0",
+                "safe-buffer": "~5.1.0",
+                "ultron": "~1.1.0"
+              }
+            },
+            "xhr": {
+              "version": "2.5.0",
+              "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.5.0.tgz",
+              "integrity": "sha512-4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==",
+              "dev": true,
+              "requires": {
+                "global": "~4.3.0",
+                "is-function": "^1.0.1",
+                "parse-headers": "^2.0.0",
+                "xtend": "^4.0.0"
+              }
+            },
+            "xhr-request": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
+              "integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
+              "dev": true,
+              "requires": {
+                "buffer-to-arraybuffer": "^0.0.5",
+                "object-assign": "^4.1.1",
+                "query-string": "^5.0.1",
+                "simple-get": "^2.7.0",
+                "timed-out": "^4.0.1",
+                "url-set-query": "^1.0.0",
+                "xhr": "^2.0.4"
+              }
+            },
+            "xhr-request-promise": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.2.tgz",
+              "integrity": "sha1-NDxE0e53JrhkgGloLQ+EDIO0Jh0=",
+              "dev": true,
+              "requires": {
+                "xhr-request": "^1.0.1"
+              }
+            },
+            "xhr2-cookies": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
+              "integrity": "sha1-fXdEnQmZGX8VXLc7I99yUF7YnUg=",
+              "dev": true,
+              "requires": {
+                "cookiejar": "^2.1.1"
+              }
+            },
+            "xtend": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+              "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+              "dev": true
+            },
+            "y18n": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+              "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+              "dev": true
+            },
+            "yaeti": {
+              "version": "0.0.6",
+              "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+              "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
+            },
+            "yargs": {
+              "version": "4.8.1",
+              "resolved": "http://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
+              "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+              "dev": true,
+              "requires": {
+                "cliui": "^3.2.0",
+                "decamelize": "^1.1.1",
+                "get-caller-file": "^1.0.1",
+                "lodash.assign": "^4.0.3",
+                "os-locale": "^1.4.0",
+                "read-pkg-up": "^1.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^1.0.1",
+                "which-module": "^1.0.0",
+                "window-size": "^0.2.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^2.4.1"
+              }
+            },
+            "yargs-parser": {
+              "version": "2.4.1",
+              "resolved": "http://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+              "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+              "dev": true,
+              "requires": {
+                "camelcase": "^3.0.0",
+                "lodash.assign": "^4.0.6"
+              }
+            },
+            "yauzl": {
+              "version": "2.10.0",
+              "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+              "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "buffer-crc32": "~0.2.3",
+                "fd-slicer": "~1.1.0"
+              }
+            }
+          }
+        },
+        "get-caller-file": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+          "dev": true
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+          "dev": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+          "dev": true
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+          "dev": true,
+          "requires": {
+            "invert-kv": "^1.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+          "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+          "dev": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "mem": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "dev": true,
+          "requires": {
+            "path-key": "^2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "dev": true
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "dev": true,
+          "requires": {
+            "execa": "^0.7.0",
+            "lcid": "^1.0.0",
+            "mem": "^1.1.0"
+          }
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+          "dev": true
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+          "dev": true
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+          "dev": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.9",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
+          "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "strip-eof": {
+          "version": "1.0.0",
+          "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+          "dev": true
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+              "dev": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            }
+          }
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "dev": true
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "11.1.0",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+          "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
+          "dev": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.1.1",
+            "find-up": "^2.1.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^9.0.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "9.0.2",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+          "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0"
+          }
+        }
       }
     },
     "gar": {
@@ -2845,14 +8998,14 @@
       }
     },
     "gc-stats": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gc-stats/-/gc-stats-1.2.0.tgz",
-      "integrity": "sha512-Fv+EbJ1zhI+HWJ1GknC4Tn90KcovQIGQgYbJp85GY7pluRj6n0feIIwdKgeSY3lG5fno2XdyUTZKtIWLdHF22Q==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/gc-stats/-/gc-stats-1.2.1.tgz",
+      "integrity": "sha512-CPQfMBQPGkqG4upxCn4zHxYZo20woPClSeqnC/WK8pFqlfAtz6zpxbOfnmxOIDYiC26H/pYlWQfdoPVGoqxFUA==",
       "dev": true,
       "optional": true,
       "requires": {
         "nan": "^2.10.0",
-        "node-pre-gyp": "^0.10.0"
+        "node-pre-gyp": "^0.11.0"
       },
       "dependencies": {
         "abbrev": {
@@ -2897,7 +9050,7 @@
           }
         },
         "chownr": {
-          "version": "1.0.1",
+          "version": "1.1.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -3002,7 +9155,7 @@
           "optional": true
         },
         "iconv-lite": {
-          "version": "0.4.23",
+          "version": "0.4.24",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -3068,7 +9221,7 @@
           "dev": true
         },
         "minipass": {
-          "version": "2.3.3",
+          "version": "2.3.5",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -3077,7 +9230,7 @@
           }
         },
         "minizlib": {
-          "version": "1.1.0",
+          "version": "1.1.1",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -3100,7 +9253,7 @@
           "optional": true
         },
         "needle": {
-          "version": "2.2.1",
+          "version": "2.2.4",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -3119,38 +9272,21 @@
           }
         },
         "node-pre-gyp": {
-          "version": "0.10.0",
+          "version": "0.11.0",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
             "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
+            "needle": "^2.2.1",
             "nopt": "^4.0.1",
             "npm-packlist": "^1.1.6",
             "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
+            "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
             "tar": "^4"
-          },
-          "dependencies": {
-            "tar": {
-              "version": "4.4.4",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "chownr": "^1.0.1",
-                "fs-minipass": "^1.2.5",
-                "minipass": "^2.3.3",
-                "minizlib": "^1.1.0",
-                "mkdirp": "^0.5.0",
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.2"
-              }
-            }
           }
         },
         "nopt": {
@@ -3164,13 +9300,13 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.3",
+          "version": "1.0.5",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.1.10",
+          "version": "1.1.12",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -3350,6 +9486,21 @@
           "dev": true,
           "optional": true
         },
+        "tar": {
+          "version": "4.4.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.3",
+            "minizlib": "^1.1.0",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
+          }
+        },
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
@@ -3413,12 +9564,6 @@
       "requires": {
         "assert-plus": "^1.0.0"
       }
-    },
-    "git-validate": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/git-validate/-/git-validate-2.2.4.tgz",
-      "integrity": "sha512-BM49gj2g/VtV+AvsaGYfIXavVyWUfqcJt2klTOr7kji/HYqpgwB6CmlevIJuPyGoBPkIUUXNSov33Ht22juh0Q==",
-      "dev": true
     },
     "github-from-package": {
       "version": "0.0.0",
@@ -3679,9 +9824,9 @@
       }
     },
     "hash.js": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.5.tgz",
-      "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.3",
@@ -3689,9 +9834,9 @@
       }
     },
     "hashlru": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.2.1.tgz",
-      "integrity": "sha1-EPIJmg18BaQPK+r1wdOc8vfavzY=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
+      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A==",
       "dev": true
     },
     "hat": {
@@ -3961,13 +10106,12 @@
       "dev": true
     },
     "interface-connection": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/interface-connection/-/interface-connection-0.3.2.tgz",
-      "integrity": "sha1-5JSYg/bqeft+3QHuP0/KR6Kf0sQ=",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/interface-connection/-/interface-connection-0.3.3.tgz",
+      "integrity": "sha512-OV9Rj7AhUlssWJTO6nOazJdPFGqWDOVZ3j5aM+i0RPKyTzR87vJ949VqhMyKkCIR0GBAaNqfB7F4YA70a/QWiw==",
       "dev": true,
       "requires": {
-        "pull-defer": "~0.2.2",
-        "timed-tape": "~0.1.1"
+        "pull-defer": "~0.2.3"
       }
     },
     "interface-datastore": {
@@ -4304,9 +10448,9 @@
       }
     },
     "ipfs-bitswap": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/ipfs-bitswap/-/ipfs-bitswap-0.21.0.tgz",
-      "integrity": "sha512-gsKGv3pa98jVQZURZcubW/LPpj0SX2UjISosF+7Nnmp4oR1RtTNBIhY+OyvlNGMWo8BqfVZb/iB0Z1+FME6CAw==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/ipfs-bitswap/-/ipfs-bitswap-0.21.1.tgz",
+      "integrity": "sha512-uuT0evC8Kv39NwHUf/wa21DplFEMCV9A2pdIRI7BJi0R4i2rDTEXoLXu5/ivWvVrNU22JDUyvROOpp6Dh0Gd4Q==",
       "dev": true,
       "requires": {
         "async": "^2.6.1",
@@ -4390,11 +10534,11 @@
       }
     },
     "ipfs-log": {
-      "version": "github:orbitdb/ipfs-log#febec397361594913fa6aad35f29de85cc526e28",
-      "from": "github:orbitdb/ipfs-log",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/ipfs-log/-/ipfs-log-4.1.2.tgz",
+      "integrity": "sha512-YYP3vhoFgxGAZk1fzf72Wst0e6Y00GHslbNImkmxaQavNH0Qg5LFrmlNmlGEaRnl17z8vkrX8PKdgS8YnIvHzg==",
       "dev": true,
       "requires": {
-        "orbit-db-identity-provider": "^0.0.3",
         "p-map": "^1.1.1",
         "p-whilst": "^1.0.0"
       }
@@ -4491,9 +10635,9 @@
       }
     },
     "ipfs-repo": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/ipfs-repo/-/ipfs-repo-0.25.0.tgz",
-      "integrity": "sha512-P/QGkWTaI5Vp9HLQssCkxhmbu0uZ3fINQWooSAAk3Kp647OIgXC5CWXALA/xlxAsyn1PxqlHZ9yLFOc8eJP5wg==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/ipfs-repo/-/ipfs-repo-0.25.2.tgz",
+      "integrity": "sha512-TuhUdturwwG/hKdK2m1fv6Hz1hvHsdXQqAsDr0uEXK8WOfz7CZ9IHLU3feDTDhh8nr4fB0nOO5xaTz3cCZ+/9Q==",
       "dev": true,
       "requires": {
         "async": "^2.6.1",
@@ -4506,11 +10650,11 @@
         "debug": "^4.1.0",
         "interface-datastore": "~0.6.0",
         "ipfs-block": "~0.7.1",
-        "lock-me": "^1.0.4",
         "lodash.get": "^4.4.2",
         "lodash.has": "^4.5.2",
         "lodash.set": "^4.3.2",
         "multiaddr": "^5.0.0",
+        "proper-lockfile": "^3.2.0",
         "pull-stream": "^3.6.9",
         "sort-keys": "^2.0.0"
       },
@@ -4817,16 +10961,15 @@
       }
     },
     "ipld-bitcoin": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/ipld-bitcoin/-/ipld-bitcoin-0.1.8.tgz",
-      "integrity": "sha512-k/iSoZTDKWKxW3kXbhfWIsdU57HneGUhmUzSty/3nABZ0jw6dBRiJ70vXAVq8FRooNIbAR734H9CgelkxGCeSQ==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/ipld-bitcoin/-/ipld-bitcoin-0.1.9.tgz",
+      "integrity": "sha512-50aih5PpUbu2gURijdYAZbldnmu5qrXu+VMWHVqCKmm9MUkOeBT67kzoLDWK95oWN+ahpfTaIMqPh2I3RreCCA==",
       "dev": true,
       "requires": {
         "async": "^2.6.1",
-        "bitcoinjs-lib": "^3.3.2",
-        "cids": "~0.5.2",
-        "git-validate": "^2.2.2",
-        "multihashes": "~0.4.12",
+        "bitcoinjs-lib": "^4.0.2",
+        "cids": "~0.5.6",
+        "multihashes": "~0.4.14",
         "multihashing-async": "~0.5.1"
       }
     },
@@ -5167,14 +11310,14 @@
       }
     },
     "is-ipfs": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/is-ipfs/-/is-ipfs-0.4.7.tgz",
-      "integrity": "sha512-u+LzRRA5s2XMJnQ65R60SvRKb8R04ZITbbRMWBESLyLPlJ+J78zaXZzNZBIf4SQ0pnWioMNCpiIV4hw098MgOQ==",
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/is-ipfs/-/is-ipfs-0.4.8.tgz",
+      "integrity": "sha512-xIKUeA24IFMfkmeAPEOZL448X7a08c/KzAGQp1e/QxC9bx/NNEdT/ohob3SW6eJO2UwJNjsbfMeNZ2B+Dk2Fdg==",
       "dev": true,
       "requires": {
         "bs58": "4.0.1",
-        "cids": "~0.5.5",
-        "multibase": "~0.4.0",
+        "cids": "~0.5.6",
+        "multibase": "~0.6.0",
         "multihashes": "~0.4.13"
       },
       "dependencies": {
@@ -5188,9 +11331,9 @@
           }
         },
         "multibase": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.4.0.tgz",
-          "integrity": "sha512-fnYvZJWDn3eSJ7EeWvS8zbOpRwuyPHpDggSnqGXkQMvYED5NdO9nyqnZboGvAT+r/60J8KZ09tW8YJHkS22sFw==",
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.0.tgz",
+          "integrity": "sha512-R9bNLQhbD7MsitPm1NeY7w9sDgu6d7cuj25snAWH7k5PSNPSwIQQBpcpj8jx1W96dLbdigZqmUWOdQRMnAmgjA==",
           "dev": true,
           "requires": {
             "base-x": "3.0.4"
@@ -5360,9 +11503,9 @@
           },
           "dependencies": {
             "hoek": {
-              "version": "6.0.3",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.0.3.tgz",
-              "integrity": "sha512-TU6RyZ/XaQCTWRLrdqZZtZqwxUVr6PDMfi6MlWNURZ7A6czanQqX4pFE1mdOUQR9FdPCsZ0UzL8jI/izZ+eBSQ==",
+              "version": "6.1.2",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.2.tgz",
+              "integrity": "sha512-6qhh/wahGYZHFSFw12tBbJw5fsAhhwrrG/y3Cs0YMTv2WzMnL0oLPnQJjv1QJvEfylRSOFuP+xCu+tdx0tD16Q==",
               "dev": true
             }
           }
@@ -5377,7 +11520,7 @@
     },
     "joi-multiaddr": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/joi-multiaddr/-/joi-multiaddr-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/joi-multiaddr/-/joi-multiaddr-2.0.0.tgz",
       "integrity": "sha512-7dJLwgplwRnIQAlC+zTuX3jkk3uXVa/RKm7GDfNO3NqmjiYgwAet8yprIdilki1WhdkJJMLuTNDf49uFNru68A==",
       "dev": true,
       "requires": {
@@ -5671,7 +11814,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         },
@@ -5831,96 +11974,17 @@
       }
     },
     "libp2p-bootstrap": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/libp2p-bootstrap/-/libp2p-bootstrap-0.9.3.tgz",
-      "integrity": "sha512-rEVvZZCKmoJlfgSMk7JkuvsdKGpLkoPK3U47xtT+pNJC+p/LZcjSmGwxNwwJvgg3jTuy2sl23W6JRZ26AXv7Og==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/libp2p-bootstrap/-/libp2p-bootstrap-0.9.4.tgz",
+      "integrity": "sha512-P+UZIwg02Y7ZJQ5ZGAFjXB1ShhxLxGqbwmk2Oke3L8f6h2bywKIY4UQYcqP5+8QvLmD3tX2hXA83kjEh1mNl7g==",
       "dev": true,
       "requires": {
         "async": "^2.6.1",
-        "debug": "^3.1.0",
-        "mafmt": "^6.0.0",
-        "multiaddr": "^5.0.0",
-        "peer-id": "~0.10.7",
+        "debug": "^4.1.0",
+        "mafmt": "^6.0.2",
+        "multiaddr": "^5.0.2",
+        "peer-id": "~0.12.0",
         "peer-info": "~0.14.1"
-      },
-      "dependencies": {
-        "bs58": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-          "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
-          "dev": true,
-          "requires": {
-            "base-x": "^3.0.2"
-          }
-        },
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "js-sha3": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.7.0.tgz",
-          "integrity": "sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA==",
-          "dev": true
-        },
-        "libp2p-crypto": {
-          "version": "0.12.1",
-          "resolved": "http://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
-          "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
-          "dev": true,
-          "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.1.1",
-            "bs58": "^4.0.1",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.7",
-            "node-forge": "^0.7.1",
-            "pem-jwk": "^1.5.1",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
-          }
-        },
-        "multihashing-async": {
-          "version": "0.4.8",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
-          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
-          "dev": true,
-          "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
-          }
-        },
-        "peer-id": {
-          "version": "0.10.7",
-          "resolved": "http://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
-          "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
-          "dev": true,
-          "requires": {
-            "async": "^2.6.0",
-            "libp2p-crypto": "~0.12.1",
-            "lodash": "^4.17.5",
-            "multihashes": "~0.4.13"
-          }
-        },
-        "tweetnacl": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
-          "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins=",
-          "dev": true
-        }
       }
     },
     "libp2p-circuit": {
@@ -6119,17 +12183,17 @@
       }
     },
     "libp2p-floodsub": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/libp2p-floodsub/-/libp2p-floodsub-0.15.1.tgz",
-      "integrity": "sha512-3WdDZQZDteVqEuok6JCOZ8TYwB1nkDwLfnHxr5BYXaolDskzBD5KhvEiqpc9JQd4zDYF+xC5a0qc0FBylmPFIg==",
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/libp2p-floodsub/-/libp2p-floodsub-0.15.3.tgz",
+      "integrity": "sha512-pxtHddNE/qOIUiOGy98PSeDaFTYCgBZdOEtF9W6IsarfX5+F8Lkn1zUpwKdRQKPp3kafuRGlAVy5qVf0ZxpA3A==",
       "dev": true,
       "requires": {
-        "async": "^2.6.0",
+        "async": "^2.6.1",
         "bs58": "^4.0.1",
-        "debug": "^3.1.0",
-        "length-prefixed-stream": "^1.5.2",
-        "libp2p-crypto": "~0.13.0",
-        "lodash": "^4.3.0",
+        "debug": "^4.1.0",
+        "length-prefixed-stream": "^1.6.0",
+        "libp2p-crypto": "~0.14.1",
+        "lodash": "^4.17.11",
         "protons": "^1.0.1",
         "pull-pushable": "^2.2.0",
         "time-cache": "~0.3.0"
@@ -6143,147 +12207,21 @@
           "requires": {
             "base-x": "^3.0.2"
           }
-        },
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "js-sha3": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.7.0.tgz",
-          "integrity": "sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA==",
-          "dev": true
-        },
-        "libp2p-crypto": {
-          "version": "0.13.0",
-          "resolved": "http://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.13.0.tgz",
-          "integrity": "sha512-i3r1TBec/xYmC5bcpPiIs3OyUAU3iy53OdRdxqawKoWTQPjYB+TyQ4w+otT66Y0sMcw70O0wH3GFAfPmQgFn+g==",
-          "dev": true,
-          "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.2.0",
-            "bs58": "^4.0.1",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.8",
-            "node-forge": "^0.7.5",
-            "pem-jwk": "^1.5.1",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
-          }
-        },
-        "multihashing-async": {
-          "version": "0.4.8",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
-          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
-          "dev": true,
-          "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
-          "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins=",
-          "dev": true
         }
       }
     },
     "libp2p-identify": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/libp2p-identify/-/libp2p-identify-0.7.2.tgz",
-      "integrity": "sha512-zYdeUdoUfUMz4FC+eEfrE+GR3G/STTvitGB/DDOlyNdYDLDWS/R7UORppsiHFtCdUj2mEi2E6JJsUZEgeYrJhQ==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/libp2p-identify/-/libp2p-identify-0.7.3.tgz",
+      "integrity": "sha512-RnOXphXxwEzDw8e+aQIE2tqqxXEqZXf457PuzQlOdfMpxDnhHeKObXrjcyfMosyguwJeAzv1x1DJ45ZCXIXFiw==",
       "dev": true,
       "requires": {
-        "multiaddr": "^5.0.0",
-        "peer-id": "~0.10.7",
+        "multiaddr": "^5.0.2",
+        "peer-id": "~0.12.0",
         "peer-info": "~0.14.1",
         "protons": "^1.0.1",
         "pull-length-prefixed": "^1.3.0",
-        "pull-stream": "^3.6.7"
-      },
-      "dependencies": {
-        "bs58": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-          "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
-          "dev": true,
-          "requires": {
-            "base-x": "^3.0.2"
-          }
-        },
-        "js-sha3": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.7.0.tgz",
-          "integrity": "sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA==",
-          "dev": true
-        },
-        "libp2p-crypto": {
-          "version": "0.12.1",
-          "resolved": "http://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
-          "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
-          "dev": true,
-          "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.1.1",
-            "bs58": "^4.0.1",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.7",
-            "node-forge": "^0.7.1",
-            "pem-jwk": "^1.5.1",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
-          }
-        },
-        "multihashing-async": {
-          "version": "0.4.8",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
-          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
-          "dev": true,
-          "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
-          }
-        },
-        "peer-id": {
-          "version": "0.10.7",
-          "resolved": "http://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
-          "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
-          "dev": true,
-          "requires": {
-            "async": "^2.6.0",
-            "libp2p-crypto": "~0.12.1",
-            "lodash": "^4.17.5",
-            "multihashes": "~0.4.13"
-          }
-        },
-        "tweetnacl": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
-          "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins=",
-          "dev": true
-        }
+        "pull-stream": "^3.6.9"
       }
     },
     "libp2p-kad-dht": {
@@ -6468,131 +12406,16 @@
       }
     },
     "libp2p-mdns": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/libp2p-mdns/-/libp2p-mdns-0.12.0.tgz",
-      "integrity": "sha512-2K1IT8ZwnzS00Ws6MiLW89W2KAG+8NsrMez2laVZJtD9RpWBgc9+KGQ7KU1nYRyYXD/NGXNEiQ6HTkhSQvYbiQ==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/libp2p-mdns/-/libp2p-mdns-0.12.1.tgz",
+      "integrity": "sha512-WH5ZaHHQ3cvSqvD+CHXo8r+O7shn589/+t6HKPWw79EEa9JyU9T/GWmDd+3VE+ff8PcjPtF3ROdSMei3QIZQUg==",
       "dev": true,
       "requires": {
-        "libp2p-tcp": "~0.12.0",
-        "multiaddr": "^5.0.0",
-        "multicast-dns": "^7.0.0",
-        "peer-id": "~0.10.7",
+        "libp2p-tcp": "~0.13.0",
+        "multiaddr": "^5.0.2",
+        "multicast-dns": "^7.2.0",
+        "peer-id": "~0.12.0",
         "peer-info": "~0.14.1"
-      },
-      "dependencies": {
-        "bs58": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-          "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
-          "dev": true,
-          "requires": {
-            "base-x": "^3.0.2"
-          }
-        },
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "js-sha3": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.7.0.tgz",
-          "integrity": "sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA==",
-          "dev": true
-        },
-        "libp2p-crypto": {
-          "version": "0.12.1",
-          "resolved": "http://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
-          "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
-          "dev": true,
-          "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.1.1",
-            "bs58": "^4.0.1",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.7",
-            "node-forge": "^0.7.1",
-            "pem-jwk": "^1.5.1",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
-          }
-        },
-        "libp2p-tcp": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.12.1.tgz",
-          "integrity": "sha512-Vt1gLoOKAPAsgQ9IDwrwL4F5zA3gINsstwKKGgZaN5Boj/EeGghdug6vOL0TP2UKWudCuC2rCQUCPVOKZ5gYow==",
-          "dev": true,
-          "requires": {
-            "class-is": "^1.1.0",
-            "debug": "^3.1.0",
-            "interface-connection": "~0.3.2",
-            "ip-address": "^5.8.9",
-            "lodash.includes": "^4.3.0",
-            "lodash.isfunction": "^3.0.9",
-            "mafmt": "^6.0.0",
-            "multiaddr": "^4.0.0",
-            "once": "^1.4.0",
-            "stream-to-pull-stream": "^1.7.2"
-          },
-          "dependencies": {
-            "multiaddr": {
-              "version": "4.0.0",
-              "resolved": "http://registry.npmjs.org/multiaddr/-/multiaddr-4.0.0.tgz",
-              "integrity": "sha512-zUatrOCfBd/tJNOSoJ10d2EI2FDXB9PyPZhqUMdXE9mOyR3C+HLuOjga2Ga/eChwvEHIpTYRMoIKF2Nv7af2qQ==",
-              "dev": true,
-              "requires": {
-                "bs58": "^4.0.1",
-                "class-is": "^1.1.0",
-                "ip": "^1.1.5",
-                "ip-address": "^5.8.9",
-                "lodash.filter": "^4.6.0",
-                "lodash.map": "^4.6.0",
-                "varint": "^5.0.0",
-                "xtend": "^4.0.1"
-              }
-            }
-          }
-        },
-        "multihashing-async": {
-          "version": "0.4.8",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
-          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
-          "dev": true,
-          "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
-          }
-        },
-        "peer-id": {
-          "version": "0.10.7",
-          "resolved": "http://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
-          "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
-          "dev": true,
-          "requires": {
-            "async": "^2.6.0",
-            "libp2p-crypto": "~0.12.1",
-            "lodash": "^4.17.5",
-            "multihashes": "~0.4.13"
-          }
-        },
-        "tweetnacl": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
-          "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins=",
-          "dev": true
-        }
       }
     },
     "libp2p-mplex": {
@@ -6840,129 +12663,50 @@
       }
     },
     "libp2p-webrtc-star": {
-      "version": "0.15.5",
-      "resolved": "https://registry.npmjs.org/libp2p-webrtc-star/-/libp2p-webrtc-star-0.15.5.tgz",
-      "integrity": "sha512-bAI6uTcMaeHH2ZmP0f2rqgc6SCFKLGSaN55qeMdvvYv3eDUQKTHBlYZ/If7vUWNCcSgeCUAfu9Xua0a0lwiJkw==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/libp2p-webrtc-star/-/libp2p-webrtc-star-0.15.6.tgz",
+      "integrity": "sha512-BsWhqLRRMPa2QQJUkVOkWXCl7OP2/+lBQJDkjfk71lfb2OCzcRkhiZXgAxKCVpZucvBnSbRpmW6uI+6xdiItgQ==",
       "dev": true,
       "requires": {
         "async": "^2.6.1",
         "class-is": "^1.1.0",
-        "debug": "^3.1.0",
-        "detect-node": "^2.0.3",
-        "epimetheus": "^1.0.55",
+        "debug": "^4.1.0",
+        "detect-node": "^2.0.4",
+        "epimetheus": "^1.0.92",
         "hapi": "^16.6.2",
         "inert": "^4.2.1",
         "interface-connection": "~0.3.2",
-        "mafmt": "^6.0.0",
+        "mafmt": "^6.0.2",
         "minimist": "^1.2.0",
-        "multiaddr": "^5.0.0",
+        "multiaddr": "^5.0.2",
         "once": "^1.4.0",
-        "peer-id": "~0.10.7",
+        "peer-id": "~0.12.0",
         "peer-info": "~0.14.1",
-        "pull-stream": "^3.6.8",
+        "pull-stream": "^3.6.9",
         "simple-peer": "^9.1.2",
         "socket.io": "^2.1.1",
         "socket.io-client": "^2.1.1",
         "stream-to-pull-stream": "^1.7.2",
         "webrtcsupport": "github:ipfs/webrtcsupport#0669f576582c53a3a42aa5ac014fcc5966809615"
-      },
-      "dependencies": {
-        "bs58": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-          "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
-          "dev": true,
-          "requires": {
-            "base-x": "^3.0.2"
-          }
-        },
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "js-sha3": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.7.0.tgz",
-          "integrity": "sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA==",
-          "dev": true
-        },
-        "libp2p-crypto": {
-          "version": "0.12.1",
-          "resolved": "http://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
-          "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
-          "dev": true,
-          "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.1.1",
-            "bs58": "^4.0.1",
-            "keypair": "^1.0.1",
-            "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.7",
-            "node-forge": "^0.7.1",
-            "pem-jwk": "^1.5.1",
-            "protons": "^1.0.1",
-            "rsa-pem-to-jwk": "^1.1.3",
-            "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
-          }
-        },
-        "multihashing-async": {
-          "version": "0.4.8",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
-          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
-          "dev": true,
-          "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
-          }
-        },
-        "peer-id": {
-          "version": "0.10.7",
-          "resolved": "http://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
-          "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
-          "dev": true,
-          "requires": {
-            "async": "^2.6.0",
-            "libp2p-crypto": "~0.12.1",
-            "lodash": "^4.17.5",
-            "multihashes": "~0.4.13"
-          }
-        },
-        "tweetnacl": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
-          "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins=",
-          "dev": true
-        }
       }
     },
     "libp2p-websocket-star": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/libp2p-websocket-star/-/libp2p-websocket-star-0.9.0.tgz",
-      "integrity": "sha512-1moYa1geS0Tj0w9bTNngnnC6dE3wm0EiLRr0A60RLoOI7OrkxoLGBbPCA1m5f5OCXlCXZae7RgP2Yo9Qfj42mQ==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/libp2p-websocket-star/-/libp2p-websocket-star-0.9.1.tgz",
+      "integrity": "sha512-OdQ31meWB5uisi69xNS+ePfrY+ebwNNnm2mgCynZhBvgUvglZscb5HpOQ4Syg4AwyUrZUlCPblW6jmIBPtUFBQ==",
       "dev": true,
       "requires": {
         "async": "^2.6.1",
         "class-is": "^1.1.0",
         "data-queue": "0.0.3",
-        "debug": "^3.1.0",
+        "debug": "^4.1.0",
         "interface-connection": "~0.3.2",
-        "libp2p-crypto": "~0.14.0",
+        "libp2p-crypto": "~0.14.1",
         "mafmt": "^6.0.2",
         "merge-recursive": "0.0.3",
-        "multiaddr": "^5.0.0",
+        "multiaddr": "^5.0.2",
         "once": "^1.4.0",
-        "peer-id": "~0.11.0",
+        "peer-id": "~0.12.0",
         "peer-info": "~0.14.1",
         "pull-stream": "^3.6.9",
         "socket.io-client": "^2.1.1",
@@ -6970,85 +12714,6 @@
         "uuid": "^3.3.2"
       },
       "dependencies": {
-        "bs58": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-          "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
-          "dev": true,
-          "requires": {
-            "base-x": "^3.0.2"
-          }
-        },
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "js-sha3": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.7.0.tgz",
-          "integrity": "sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA==",
-          "dev": true
-        },
-        "multihashing-async": {
-          "version": "0.4.8",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
-          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
-          "dev": true,
-          "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
-          }
-        },
-        "peer-id": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.11.0.tgz",
-          "integrity": "sha512-C/lRJk4CWIgOdKvfO572NvHbPcUwe49I6G0toIhDB5tCohqv/qzy0uBcAK9Ww8TvYI6U4J3C8ACShV9fWjNU4w==",
-          "dev": true,
-          "requires": {
-            "async": "^2.6.1",
-            "libp2p-crypto": "~0.13.0",
-            "lodash": "^4.17.10",
-            "multihashes": "~0.4.13"
-          },
-          "dependencies": {
-            "libp2p-crypto": {
-              "version": "0.13.0",
-              "resolved": "http://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.13.0.tgz",
-              "integrity": "sha512-i3r1TBec/xYmC5bcpPiIs3OyUAU3iy53OdRdxqawKoWTQPjYB+TyQ4w+otT66Y0sMcw70O0wH3GFAfPmQgFn+g==",
-              "dev": true,
-              "requires": {
-                "asn1.js": "^5.0.0",
-                "async": "^2.6.0",
-                "browserify-aes": "^1.2.0",
-                "bs58": "^4.0.1",
-                "keypair": "^1.0.1",
-                "libp2p-crypto-secp256k1": "~0.2.2",
-                "multihashing-async": "~0.4.8",
-                "node-forge": "^0.7.5",
-                "pem-jwk": "^1.5.1",
-                "protons": "^1.0.1",
-                "rsa-pem-to-jwk": "^1.1.3",
-                "tweetnacl": "^1.0.0",
-                "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
-              }
-            }
-          }
-        },
-        "tweetnacl": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
-          "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins=",
-          "dev": true
-        },
         "uuid": {
           "version": "3.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
@@ -7098,19 +12763,6 @@
       "requires": {
         "p-locate": "^3.0.0",
         "path-exists": "^3.0.0"
-      }
-    },
-    "lock-me": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lock-me/-/lock-me-1.0.4.tgz",
-      "integrity": "sha512-PH/uZMCtlTfiPcKnNVc8cF57Jrc9uTcil4qL6f1faTWV71J3ym8LIlaO385BtoC3MQb+jt3t2R8SnHxcQ5pafw==",
-      "dev": true,
-      "requires": {
-        "async": "^2.1.5",
-        "find-process": "^1.0.5",
-        "fs-ext": "github:baudehlo/node-fs-ext#2ba366d9fc67ef3ab165e239068924b276ecf249",
-        "nodeify": "^1.0.1",
-        "once": "^1.4.0"
       }
     },
     "lodash": {
@@ -7303,9 +12955,9 @@
       }
     },
     "lru-cache": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "dev": true,
       "requires": {
         "pseudomap": "^1.0.2",
@@ -7319,12 +12971,39 @@
       "dev": true
     },
     "mafmt": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-6.0.2.tgz",
-      "integrity": "sha512-+ydrVDp/bo2GPTNN0378AFX66IJBlbrIBY0RaILWC9AICr9kviX5fonHeKsZiesEuuYetQeRhnZPL/J2k8vHAA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-6.0.3.tgz",
+      "integrity": "sha512-VtaYiM1oQu3zmT9iejn2fFkAse1PtG1ytWr+AqeydTqpIpnYp9ycipQEJSP9yeZnQSqVmXVlErkgjG4WnAkk8A==",
       "dev": true,
       "requires": {
-        "multiaddr": "^5.0.0"
+        "multiaddr": "^6.0.0"
+      },
+      "dependencies": {
+        "bs58": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+          "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.2"
+          }
+        },
+        "multiaddr": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-6.0.0.tgz",
+          "integrity": "sha512-2jZgvRFd2C7cNV6l0O5232/ZEnKN6PO+7xDw0haJ/Uh92Zgna6K98JvLykBodMXwXcbTY8j9kxu8Zi6NYGpuMQ==",
+          "dev": true,
+          "requires": {
+            "bs58": "^4.0.1",
+            "class-is": "^1.1.0",
+            "ip": "^1.1.5",
+            "ip-address": "^5.8.9",
+            "lodash.filter": "^4.6.0",
+            "lodash.map": "^4.6.0",
+            "varint": "^5.0.0",
+            "xtend": "^4.0.1"
+          }
+        }
       }
     },
     "make-dir": {
@@ -7381,7 +13060,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
@@ -7601,7 +13280,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
@@ -7624,9 +13303,9 @@
       }
     },
     "mime": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
-      "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
+      "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w==",
       "dev": true
     },
     "mime-db": {
@@ -8290,7 +13969,7 @@
         "ipfs-pubsub-1on1": "~0.0.4",
         "logplease": "^1.2.14",
         "multihashes": "^0.4.12",
-        "orbit-db-access-controllers": "github:orbitdb/orbit-db-access-controllers#fde18727639b7fe05d9ec251d86fd0d4956098d3",
+        "orbit-db-access-controllers": "github:orbitdb/orbit-db-access-controllers#3f9821bb7a481df8b3174ab627ef2b5841c15b7a",
         "orbit-db-cache": "~0.2.4",
         "orbit-db-counterstore": "github:shamb0t/orbit-db-counterstore#4bd6942f5d1c2498134ee8504e99744346780e2f",
         "orbit-db-docstore": "~1.4.3",
@@ -8301,10 +13980,17 @@
         "orbit-db-kvstore": "~1.4.0",
         "orbit-db-pubsub": "~0.5.5",
         "orbit-db-store": "github:shamb0t/orbit-db-store#b5483fe3beec72fb8c98f993ea42b1345467ffd2"
+      },
+      "dependencies": {
+        "orbit-db-identity-provider": {
+          "version": "github:orbitdb/orbit-db-identity-provider#6f788cb0edca0cc46f8bc3df47187f00280c0bab",
+          "from": "github:orbitdb/orbit-db-identity-provider#feat/verify-identity",
+          "dev": true
+        }
       }
     },
     "orbit-db-access-controllers": {
-      "version": "github:orbitdb/orbit-db-access-controllers#fde18727639b7fe05d9ec251d86fd0d4956098d3",
+      "version": "github:orbitdb/orbit-db-access-controllers#3f9821bb7a481df8b3174ab627ef2b5841c15b7a",
       "from": "github:orbitdb/orbit-db-access-controllers",
       "dev": true
     },
@@ -8341,15 +14027,15 @@
       "dev": true,
       "requires": {
         "crdts": "~0.1.2",
-        "orbit-db-store": "github:orbitdb/orbit-db-store#b5483fe3beec72fb8c98f993ea42b1345467ffd2"
+        "orbit-db-store": "github:orbitdb/orbit-db-store#d502fb77e65b774fb38e428eb12039156dc8e55e"
       },
       "dependencies": {
         "orbit-db-store": {
-          "version": "github:orbitdb/orbit-db-store#b5483fe3beec72fb8c98f993ea42b1345467ffd2",
+          "version": "github:orbitdb/orbit-db-store#d502fb77e65b774fb38e428eb12039156dc8e55e",
           "from": "github:orbitdb/orbit-db-store",
           "dev": true,
           "requires": {
-            "ipfs-log": "github:orbitdb/ipfs-log#febec397361594913fa6aad35f29de85cc526e28",
+            "ipfs-log": "~4.1.0",
             "logplease": "^1.2.14",
             "p-each-series": "^1.0.0",
             "readable-stream": "~2.3.5"
@@ -8394,8 +14080,8 @@
       }
     },
     "orbit-db-identity-provider": {
-      "version": "github:orbitdb/orbit-db-identity-provider#6f788cb0edca0cc46f8bc3df47187f00280c0bab",
-      "from": "github:orbitdb/orbit-db-identity-provider#feat/verify-identity",
+      "version": "github:orbitdb/orbit-db-identity-provider#cb29b323ee8f1fcb8562ec0f9581dc96eae19837",
+      "from": "github:orbitdb/orbit-db-identity-provider#feat/resolvers",
       "dev": true
     },
     "orbit-db-keystore": {
@@ -8434,10 +14120,22 @@
       "from": "github:shamb0t/orbit-db-store#feat/new-ipfs-log",
       "dev": true,
       "requires": {
-        "ipfs-log": "github:orbitdb/ipfs-log#febec397361594913fa6aad35f29de85cc526e28",
+        "ipfs-log": "github:orbitdb/ipfs-log#60e238fd47e06db8a3dded641f006695ebc39bad",
         "logplease": "^1.2.14",
         "p-each-series": "^1.0.0",
         "readable-stream": "~2.3.5"
+      },
+      "dependencies": {
+        "ipfs-log": {
+          "version": "github:orbitdb/ipfs-log#60e238fd47e06db8a3dded641f006695ebc39bad",
+          "from": "github:orbitdb/ipfs-log",
+          "dev": true,
+          "requires": {
+            "orbit-db-identity-provider": "^0.0.3",
+            "p-map": "^1.1.1",
+            "p-whilst": "^1.0.0"
+          }
+        }
       }
     },
     "os-homedir": {
@@ -8598,7 +14296,7 @@
     },
     "pako": {
       "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "resolved": "http://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
       "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
       "dev": true
     },
@@ -8889,7 +14587,7 @@
     },
     "peer-info": {
       "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.14.1.tgz",
+      "resolved": "http://registry.npmjs.org/peer-info/-/peer-info-0.14.1.tgz",
       "integrity": "sha512-I9K+q7sisU0gg5ej6ekbhgolwlcm1tc2wDtLmumptoLYx0DkIT8WVHtgoTnupYwRRqcYADtwddFdiXfb8QFqzg==",
       "dev": true,
       "requires": {
@@ -9156,9 +14854,9 @@
       "dev": true
     },
     "progress": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
-      "integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
     "prom-client": {
@@ -9172,13 +14870,13 @@
       }
     },
     "prometheus-gc-stats": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/prometheus-gc-stats/-/prometheus-gc-stats-0.6.0.tgz",
-      "integrity": "sha512-4kC+sGrSYT653/gDrnoeEISuM9wueSy524xvGzKpHA6Xf6xgTL5cpOxgBmrOyRDv8VvJPZ6lLTcRlBfmvOoeUw==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/prometheus-gc-stats/-/prometheus-gc-stats-0.6.1.tgz",
+      "integrity": "sha512-DUo/cDs+1XcVuqoFU6+DjmWjkjIRIVeswtZAIfslIPrYfli2NK0/g/BPoO/kqOgLvzbKRx4m9+MDeNsNIIJGkg==",
       "dev": true,
       "optional": true,
       "requires": {
-        "gc-stats": "^1.2.0",
+        "gc-stats": "^1.2.1",
         "optional": "^0.1.3"
       }
     },
@@ -9202,6 +14900,25 @@
       "resolved": "https://registry.npmjs.org/promisify-es6/-/promisify-es6-1.0.3.tgz",
       "integrity": "sha512-N9iVG+CGJsI4b4ZGazjwLnxErD2d9Pe4DPvvXSxYA9tFNu8ymXME4Qs5HIQ0LMJpNM7zj+m0NlNnNeqFpKzqnA==",
       "dev": true
+    },
+    "proper-lockfile": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-3.2.0.tgz",
+      "integrity": "sha512-iMghHHXv2bsxl6NchhEaFck8tvX3F9cknEEh1SUpguUOBjN7PAAW9BLzmbc1g/mCD1gY3EE2EABBHPJfFdHFmA==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.15",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+          "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+          "dev": true
+        }
+      }
     },
     "protocol-buffers-schema": {
       "version": "3.3.2",
@@ -9525,7 +15242,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
@@ -9560,7 +15277,7 @@
     },
     "pushdata-bitcoin": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pushdata-bitcoin/-/pushdata-bitcoin-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/pushdata-bitcoin/-/pushdata-bitcoin-1.0.1.tgz",
       "integrity": "sha1-FZMdPNlnreUiBvUjqnMxrvfUOvc=",
       "dev": true,
       "requires": {
@@ -9826,6 +15543,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "dev": true
+    },
+    "retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
       "dev": true
     },
     "rimraf": {
@@ -10305,7 +16028,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
@@ -10324,34 +16047,17 @@
       "dev": true
     },
     "socket.io": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.1.1.tgz",
-      "integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.2.0.tgz",
+      "integrity": "sha512-wxXrIuZ8AILcn+f1B4ez4hJTPG24iNgxBBDaJfT6MsyOhVYiTXWexGoPkd87ktJG8kQEcL/NBvRi64+9k4Kc0w==",
       "dev": true,
       "requires": {
-        "debug": "~3.1.0",
-        "engine.io": "~3.2.0",
+        "debug": "~4.1.0",
+        "engine.io": "~3.3.1",
         "has-binary2": "~1.0.2",
         "socket.io-adapter": "~1.1.0",
-        "socket.io-client": "2.1.1",
-        "socket.io-parser": "~3.2.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        }
+        "socket.io-client": "2.2.0",
+        "socket.io-parser": "~3.3.0"
       }
     },
     "socket.io-adapter": {
@@ -10361,9 +16067,9 @@
       "dev": true
     },
     "socket.io-client": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.1.1.tgz",
-      "integrity": "sha512-jxnFyhAuFxYfjqIgduQlhzqTcOEQSn+OHKVfAxWaNWa7ecP7xSNk2Dx/3UEsDcY7NcFafxvNvKPmmO7HTwTxGQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.2.0.tgz",
+      "integrity": "sha512-56ZrkTDbdTLmBIyfFYesgOxsjcLnwAKoN4CiPyTVkMQj3zTUh0QAx3GbvIvLpFEOvQWu92yyWICxB0u7wkVbYA==",
       "dev": true,
       "requires": {
         "backo2": "1.0.2",
@@ -10371,14 +16077,14 @@
         "component-bind": "1.0.0",
         "component-emitter": "1.2.1",
         "debug": "~3.1.0",
-        "engine.io-client": "~3.2.0",
+        "engine.io-client": "~3.3.1",
         "has-binary2": "~1.0.2",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "object-component": "0.0.3",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "socket.io-parser": "~3.2.0",
+        "socket.io-parser": "~3.3.0",
         "to-array": "0.1.4"
       },
       "dependencies": {
@@ -10400,9 +16106,9 @@
       }
     },
     "socket.io-parser": {
-      "version": "3.2.0",
-      "resolved": "http://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
-      "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
+      "integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
       "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
@@ -10488,32 +16194,16 @@
         "is-plain-obj": "^1.0.0"
       }
     },
-    "source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
-    },
-    "source-map-support": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
-      "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
-      "dev": true,
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
     "sparse-array": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/sparse-array/-/sparse-array-1.3.1.tgz",
-      "integrity": "sha1-1Wm5i55JIz1EGN5gmFAqSmxB2Dw=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/sparse-array/-/sparse-array-1.3.2.tgz",
+      "integrity": "sha512-ZT711fePGn3+kQyLuv1fpd3rNSkNF8vd5Kv2D+qnOANeyKs3fx6bUMGWRPvgTTcYV64QMqZKZwcuaQSP3AZ0tg==",
       "dev": true
     },
     "spdx-correct": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
-      "integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
       "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
@@ -10719,7 +16409,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
@@ -11136,17 +16826,24 @@
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
       "dev": true
     },
-    "timed-tape": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/timed-tape/-/timed-tape-0.1.1.tgz",
-      "integrity": "sha1-m25WnxfmbHnx7tLSX/eWL8dBjkk=",
-      "dev": true
-    },
     "tiny-each-async": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/tiny-each-async/-/tiny-each-async-2.0.3.tgz",
       "integrity": "sha1-jru/1tYpXxNwAD+7NxYq/loKUdE=",
       "dev": true
+    },
+    "tiny-secp256k1": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.0.1.tgz",
+      "integrity": "sha512-Wz2kMPWtCI5XBftFeF3bUL8uz2+VlasniKwOkRPjvL7h1QVd9rbhrve/HWUu747kJKzVf1XHonzcdM4Ut8fvww==",
+      "dev": true,
+      "requires": {
+        "bindings": "^1.3.0",
+        "bn.js": "^4.11.8",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.4.0",
+        "nan": "^2.10.0"
+      }
     },
     "to-array": {
       "version": "0.1.4",
@@ -11263,9 +16960,9 @@
       }
     },
     "typeforce": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.16.0.tgz",
-      "integrity": "sha512-V60F7OHPH7vPlgIU73vYyeebKxWjQqCTlge+MvKlVn09PIhCOi/ZotowYdgREHB5S1dyHOr906ui6NheYXjlVQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
+      "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==",
       "dev": true
     },
     "ultron": {
@@ -11305,7 +17002,7 @@
     },
     "underscore": {
       "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
       "dev": true
     },
@@ -11358,7 +17055,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
@@ -11527,24 +17224,24 @@
       }
     },
     "web3": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.36.tgz",
-      "integrity": "sha512-fZDunw1V0AQS27r5pUN3eOVP7u8YAvyo6vOapdgVRolAu5LgaweP7jncYyLINqIX9ZgWdS5A090bt+ymgaYHsw==",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.37.tgz",
+      "integrity": "sha512-8XLgUspdzicC/xHG82TLrcF/Fxzj2XYNJ1KTYnepOI77bj5rvpsxxwHYBWQ6/JOjk0HkZqoBfnXWgcIHCDhZhQ==",
       "dev": true,
       "requires": {
-        "web3-bzz": "1.0.0-beta.36",
-        "web3-core": "1.0.0-beta.36",
-        "web3-eth": "1.0.0-beta.36",
-        "web3-eth-personal": "1.0.0-beta.36",
-        "web3-net": "1.0.0-beta.36",
-        "web3-shh": "1.0.0-beta.36",
-        "web3-utils": "1.0.0-beta.36"
+        "web3-bzz": "1.0.0-beta.37",
+        "web3-core": "1.0.0-beta.37",
+        "web3-eth": "1.0.0-beta.37",
+        "web3-eth-personal": "1.0.0-beta.37",
+        "web3-net": "1.0.0-beta.37",
+        "web3-shh": "1.0.0-beta.37",
+        "web3-utils": "1.0.0-beta.37"
       }
     },
     "web3-bzz": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.36.tgz",
-      "integrity": "sha512-clDRS/ziboJ5ytnrfxq80YSu9HQsT0vggnT3BkoXadrauyEE/9JNLxRu016jjUxqdkfdv4MgIPDdOS3Bv2ghiw==",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.37.tgz",
+      "integrity": "sha512-E+dho49Nsm/QpQvYWOF35YDsQrMvLB19AApENxhlQsu6HpWQt534DQul0t3Y/aAh8rlKD6Kanxt8LhHDG3vejQ==",
       "dev": true,
       "requires": {
         "got": "7.1.0",
@@ -11577,45 +17274,45 @@
       }
     },
     "web3-core": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.36.tgz",
-      "integrity": "sha512-C2QW9CMMRZdYAiKiLkMrKRSp+gekSqTDgZTNvlxAdN1hXn4d9UmcmWSJXOmIHqr5N2ISbRod+bW+qChODxVE3Q==",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.37.tgz",
+      "integrity": "sha512-cIwEqCj7OJyefQNauI0HOgW4sSaOQ98V99H2/HEIlnCZylsDzfw7gtQUdwnRFiIyIxjbWy3iWsjwDPoXNPZBYg==",
       "dev": true,
       "requires": {
-        "web3-core-helpers": "1.0.0-beta.36",
-        "web3-core-method": "1.0.0-beta.36",
-        "web3-core-requestmanager": "1.0.0-beta.36",
-        "web3-utils": "1.0.0-beta.36"
+        "web3-core-helpers": "1.0.0-beta.37",
+        "web3-core-method": "1.0.0-beta.37",
+        "web3-core-requestmanager": "1.0.0-beta.37",
+        "web3-utils": "1.0.0-beta.37"
       }
     },
     "web3-core-helpers": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.36.tgz",
-      "integrity": "sha512-gu74l0htiGWuxLQuMnZqKToFvkSM+UFPE7qUuy1ZosH/h2Jd+VBWg6k4CyNYVYfP0hL5x3CN8SBmB+HMowo55A==",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.37.tgz",
+      "integrity": "sha512-efaLOzN28RMnbugnyelgLwPWWaSwElQzcAJ/x3PZu+uPloM/lE5x0YuBKvIh7/PoSMlHqtRWj1B8CpuQOUQ5Ew==",
       "dev": true,
       "requires": {
         "underscore": "1.8.3",
-        "web3-eth-iban": "1.0.0-beta.36",
-        "web3-utils": "1.0.0-beta.36"
+        "web3-eth-iban": "1.0.0-beta.37",
+        "web3-utils": "1.0.0-beta.37"
       }
     },
     "web3-core-method": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.36.tgz",
-      "integrity": "sha512-dJsP3KkGaqBBSdxfzvLsYPOmVaSs1lR/3oKob/gtUYG7UyTnwquwliAc7OXj+gqRA2E/FHZcM83cWdl31ltdSA==",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.37.tgz",
+      "integrity": "sha512-pKWFUeqnVmzx3VrZg+CseSdrl/Yrk2ioid/HzolNXZE6zdoITZL0uRjnsbqXGEzgRRd1Oe/pFndpTlRsnxXloA==",
       "dev": true,
       "requires": {
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.36",
-        "web3-core-promievent": "1.0.0-beta.36",
-        "web3-core-subscriptions": "1.0.0-beta.36",
-        "web3-utils": "1.0.0-beta.36"
+        "web3-core-helpers": "1.0.0-beta.37",
+        "web3-core-promievent": "1.0.0-beta.37",
+        "web3-core-subscriptions": "1.0.0-beta.37",
+        "web3-utils": "1.0.0-beta.37"
       }
     },
     "web3-core-promievent": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.36.tgz",
-      "integrity": "sha512-RGIL6TjcOeJTullFLMurChPTsg94cPF6LI763y/sPYtXTDol1vVa+J5aGLp/4WW8v+s+1bSQO6zYq2ZtkbmtEQ==",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.37.tgz",
+      "integrity": "sha512-GTF2r1lP8nJBeA5Gxq5yZpJy9l8Fb9CXGZPfF8jHvaRdQHtm2Z+NDhqYmF833lcdkokRSyfPcXlz1mlWeClFpg==",
       "dev": true,
       "requires": {
         "any-promise": "1.3.0",
@@ -11623,59 +17320,59 @@
       }
     },
     "web3-core-requestmanager": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.36.tgz",
-      "integrity": "sha512-/CHuaMbiMDu1v8ANGYI7yFCnh1GaCWx5pKnUPJf+QTk2xAAw+Bvd97yZJIWPOK5AOPUIzxgwx9Ob/5ln6mTmYA==",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.37.tgz",
+      "integrity": "sha512-66VUqye5BGp1Zz1r8psCxdNH+GtTjaFwroum2Osx+wbC5oRjAiXkkadiitf6wRb+edodjEMPn49u7B6WGNuewQ==",
       "dev": true,
       "requires": {
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.36",
-        "web3-providers-http": "1.0.0-beta.36",
-        "web3-providers-ipc": "1.0.0-beta.36",
-        "web3-providers-ws": "1.0.0-beta.36"
+        "web3-core-helpers": "1.0.0-beta.37",
+        "web3-providers-http": "1.0.0-beta.37",
+        "web3-providers-ipc": "1.0.0-beta.37",
+        "web3-providers-ws": "1.0.0-beta.37"
       }
     },
     "web3-core-subscriptions": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.36.tgz",
-      "integrity": "sha512-/evyLQ8CMEYXC5aUCodDpmEnmGVYQxaIjiEIfA/85f9ifHkfzP1aOwCAjcsLsJWnwrWDagxSpjCYrDtnNabdEw==",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.37.tgz",
+      "integrity": "sha512-FdXl8so9kwkRRWziuCSpFsAuAdg9KvpXa1fQlT16uoGcYYfxwFO/nkwyBGQzkZt7emShI2IRugcazyPCZDwkOA==",
       "dev": true,
       "requires": {
         "eventemitter3": "1.1.1",
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.36"
+        "web3-core-helpers": "1.0.0-beta.37"
       }
     },
     "web3-eth": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.36.tgz",
-      "integrity": "sha512-uEa0UnbnNHUB4N2O1U+LsvxzSPJ/w3azy5115IseaUdDaiz6IFFgFfFP3ssauayQNCf7v2F44GXLfPhrNeb/Sw==",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.37.tgz",
+      "integrity": "sha512-Eb3aGtkz3G9q+Z9DKgSQNbn/u8RtcZQQ0R4sW9hy5KK47GoT6vab5c6DiD3QWzI0BzitHzR5Ji+3VHf/hPUGgw==",
       "dev": true,
       "requires": {
         "underscore": "1.8.3",
-        "web3-core": "1.0.0-beta.36",
-        "web3-core-helpers": "1.0.0-beta.36",
-        "web3-core-method": "1.0.0-beta.36",
-        "web3-core-subscriptions": "1.0.0-beta.36",
-        "web3-eth-abi": "1.0.0-beta.36",
-        "web3-eth-accounts": "1.0.0-beta.36",
-        "web3-eth-contract": "1.0.0-beta.36",
-        "web3-eth-ens": "1.0.0-beta.36",
-        "web3-eth-iban": "1.0.0-beta.36",
-        "web3-eth-personal": "1.0.0-beta.36",
-        "web3-net": "1.0.0-beta.36",
-        "web3-utils": "1.0.0-beta.36"
+        "web3-core": "1.0.0-beta.37",
+        "web3-core-helpers": "1.0.0-beta.37",
+        "web3-core-method": "1.0.0-beta.37",
+        "web3-core-subscriptions": "1.0.0-beta.37",
+        "web3-eth-abi": "1.0.0-beta.37",
+        "web3-eth-accounts": "1.0.0-beta.37",
+        "web3-eth-contract": "1.0.0-beta.37",
+        "web3-eth-ens": "1.0.0-beta.37",
+        "web3-eth-iban": "1.0.0-beta.37",
+        "web3-eth-personal": "1.0.0-beta.37",
+        "web3-net": "1.0.0-beta.37",
+        "web3-utils": "1.0.0-beta.37"
       }
     },
     "web3-eth-abi": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.36.tgz",
-      "integrity": "sha512-fBfW+7hvA0rxEMV45fO7JU+0R32ayT7aRwG9Cl6NW2/QvhFeME2qVbMIWw0q5MryPZGIN8A6366hKNuWvVidDg==",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.37.tgz",
+      "integrity": "sha512-g9DKZGM2OqwKp/tX3W/yihcj7mQCtJ6CXyZXEIZfuDyRBED/iSEIFfieDOd+yo16sokLMig6FG7ADhhu+19hdA==",
       "dev": true,
       "requires": {
         "ethers": "4.0.0-beta.1",
         "underscore": "1.8.3",
-        "web3-utils": "1.0.0-beta.36"
+        "web3-utils": "1.0.0-beta.37"
       },
       "dependencies": {
         "elliptic": {
@@ -11727,9 +17424,9 @@
       }
     },
     "web3-eth-accounts": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.36.tgz",
-      "integrity": "sha512-MmgIlBEZ0ILLWV4+wfMrbeVVMU/VmQnCpgSDcw7wHKOKu47bKncJ6rVqVsUbC6d9F613Rios+Yj2Ua6SCHtmrg==",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.37.tgz",
+      "integrity": "sha512-uvbHL62/zwo4GDmwKdqH9c/EgYd8QVnAfpVw8D3epSISpgbONNY7Hr4MRMSd/CqAP12l2Ls9JVQGLhhC83bW6g==",
       "dev": true,
       "requires": {
         "any-promise": "1.3.0",
@@ -11738,10 +17435,10 @@
         "scrypt.js": "0.2.0",
         "underscore": "1.8.3",
         "uuid": "2.0.1",
-        "web3-core": "1.0.0-beta.36",
-        "web3-core-helpers": "1.0.0-beta.36",
-        "web3-core-method": "1.0.0-beta.36",
-        "web3-utils": "1.0.0-beta.36"
+        "web3-core": "1.0.0-beta.37",
+        "web3-core-helpers": "1.0.0-beta.37",
+        "web3-core-method": "1.0.0-beta.37",
+        "web3-utils": "1.0.0-beta.37"
       },
       "dependencies": {
         "eth-lib": {
@@ -11758,45 +17455,45 @@
       }
     },
     "web3-eth-contract": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.36.tgz",
-      "integrity": "sha512-cywqcIrUsCW4fyqsHdOb24OCC8AnBol8kNiptI+IHRylyCjTNgr53bUbjrXWjmEnear90rO0QhAVjLB1a4iEbQ==",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.37.tgz",
+      "integrity": "sha512-h1B3A8Z/C7BlnTCHkrWbXZQTViDxfR12lKMeTkT8Sqj5phFmxrBlPE4ORy4lf1Dk5b23mZYE0r/IRACx4ThCrQ==",
       "dev": true,
       "requires": {
         "underscore": "1.8.3",
-        "web3-core": "1.0.0-beta.36",
-        "web3-core-helpers": "1.0.0-beta.36",
-        "web3-core-method": "1.0.0-beta.36",
-        "web3-core-promievent": "1.0.0-beta.36",
-        "web3-core-subscriptions": "1.0.0-beta.36",
-        "web3-eth-abi": "1.0.0-beta.36",
-        "web3-utils": "1.0.0-beta.36"
+        "web3-core": "1.0.0-beta.37",
+        "web3-core-helpers": "1.0.0-beta.37",
+        "web3-core-method": "1.0.0-beta.37",
+        "web3-core-promievent": "1.0.0-beta.37",
+        "web3-core-subscriptions": "1.0.0-beta.37",
+        "web3-eth-abi": "1.0.0-beta.37",
+        "web3-utils": "1.0.0-beta.37"
       }
     },
     "web3-eth-ens": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.0.0-beta.36.tgz",
-      "integrity": "sha512-8ZdD7XoJfSX3jNlZHSLe4G837xQ0v5a8cHCcDcd1IoqoY855X9SrIQ0Xdqia9p4mR1YcH1vgmkXY9/3hsvxS7g==",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.0.0-beta.37.tgz",
+      "integrity": "sha512-dR3UkrVzdRrJhfP57xBPx0CMiVnCcYFvh+u2XMkGydrhHgupSUkjqGr89xry/j1T0BkuN9mikpbyhdCVMXqMbg==",
       "dev": true,
       "requires": {
         "eth-ens-namehash": "2.0.8",
         "underscore": "1.8.3",
-        "web3-core": "1.0.0-beta.36",
-        "web3-core-helpers": "1.0.0-beta.36",
-        "web3-core-promievent": "1.0.0-beta.36",
-        "web3-eth-abi": "1.0.0-beta.36",
-        "web3-eth-contract": "1.0.0-beta.36",
-        "web3-utils": "1.0.0-beta.36"
+        "web3-core": "1.0.0-beta.37",
+        "web3-core-helpers": "1.0.0-beta.37",
+        "web3-core-promievent": "1.0.0-beta.37",
+        "web3-eth-abi": "1.0.0-beta.37",
+        "web3-eth-contract": "1.0.0-beta.37",
+        "web3-utils": "1.0.0-beta.37"
       }
     },
     "web3-eth-iban": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.36.tgz",
-      "integrity": "sha512-b5AEDjjhOLR4q47Hbzf65zYE+7U7JgCgrUb13RU4HMIGoMb1q4DXaJw1UH8VVHCZulevl2QBjpCyrntecMqqCQ==",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.37.tgz",
+      "integrity": "sha512-WQRniGJFxH/XCbd7miO6+jnUG+6bvuzfeufPIiOtCbeIC1ypp1kSqER8YVBDrTyinU1xnf1U5v0KBZ2yiWBJxQ==",
       "dev": true,
       "requires": {
         "bn.js": "4.11.6",
-        "web3-utils": "1.0.0-beta.36"
+        "web3-utils": "1.0.0-beta.37"
       },
       "dependencies": {
         "bn.js": {
@@ -11808,77 +17505,77 @@
       }
     },
     "web3-eth-personal": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.36.tgz",
-      "integrity": "sha512-+oxvhojeWh4C/XtnlYURWRR3F5Cg7bQQNjtN1ZGnouKAZyBLoYDVVJ6OaPiveNtfC9RKnzLikn9/Uqc0xz410A==",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.37.tgz",
+      "integrity": "sha512-B4dZpGbD+nGnn48i6nJBqrQ+HB7oDmd+Q3wGRKOsHSK5HRWO/KwYeA7wgwamMAElkut50lIsT9EJl4Apfk3G5Q==",
       "dev": true,
       "requires": {
-        "web3-core": "1.0.0-beta.36",
-        "web3-core-helpers": "1.0.0-beta.36",
-        "web3-core-method": "1.0.0-beta.36",
-        "web3-net": "1.0.0-beta.36",
-        "web3-utils": "1.0.0-beta.36"
+        "web3-core": "1.0.0-beta.37",
+        "web3-core-helpers": "1.0.0-beta.37",
+        "web3-core-method": "1.0.0-beta.37",
+        "web3-net": "1.0.0-beta.37",
+        "web3-utils": "1.0.0-beta.37"
       }
     },
     "web3-net": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.36.tgz",
-      "integrity": "sha512-BriXK0Pjr6Hc/VDq1Vn8vyOum4JB//wpCjgeGziFD6jC7Of8YaWC7AJYXje89OckzfcqX1aJyJlBwDpasNkAzQ==",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.37.tgz",
+      "integrity": "sha512-xG/uBtMdDa1UMXw9KjDUgf3fXA/fDEJUYUS0TDn+U9PMgngA+UVECHNNvQTrVVDxEky38V3sahwIDiopNsQdsw==",
       "dev": true,
       "requires": {
-        "web3-core": "1.0.0-beta.36",
-        "web3-core-method": "1.0.0-beta.36",
-        "web3-utils": "1.0.0-beta.36"
+        "web3-core": "1.0.0-beta.37",
+        "web3-core-method": "1.0.0-beta.37",
+        "web3-utils": "1.0.0-beta.37"
       }
     },
     "web3-providers-http": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.36.tgz",
-      "integrity": "sha512-KLSqMS59nRdpet9B0B64MKgtM3n9wAHTcAHJ03hv79avQNTjHxtjZm0ttcjcFUPpWDgTCtcYCa7tqaYo9Pbeog==",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.37.tgz",
+      "integrity": "sha512-FM/1YDB1jtZuTo78habFj7S9tNHoqt0UipdyoQV29b8LkGKZV9Vs3is8L24hzuj1j/tbwkcAH+ewIseHwu0DTg==",
       "dev": true,
       "requires": {
-        "web3-core-helpers": "1.0.0-beta.36",
+        "web3-core-helpers": "1.0.0-beta.37",
         "xhr2-cookies": "1.1.0"
       }
     },
     "web3-providers-ipc": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.36.tgz",
-      "integrity": "sha512-iEUrmdd2CzoWgp+75/ydom/1IaoLw95qkAzsgwjjZp1waDncHP/cvVGX74+fbUx4hRaPdchyzxCQfNpgLDmNjQ==",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.37.tgz",
+      "integrity": "sha512-NdRPRxYMIU0C3u18NI8u4bwbhI9pCg5nRgDGYcmSAx5uOBxiYcQy+hb0WkJRRhBoyIXJmy+s26FoH8904+UnPg==",
       "dev": true,
       "requires": {
         "oboe": "2.1.3",
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.36"
+        "web3-core-helpers": "1.0.0-beta.37"
       }
     },
     "web3-providers-ws": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.36.tgz",
-      "integrity": "sha512-wAnENuZx75T5ZSrT2De2LOaUuPf2yRjq1VfcbD7+Zd79F3DZZLBJcPyCNVQ1U0fAXt0wfgCKl7sVw5pffqR9Bw==",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.37.tgz",
+      "integrity": "sha512-8p6ZLv+1JYa5Vs8oBn33Nn3VGFBbF+wVfO+b78RJS1Qf1uIOzjFVDk3XwYDD7rlz9G5BKpxhaQw+6EGQ7L02aw==",
       "dev": true,
       "requires": {
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.36",
+        "web3-core-helpers": "1.0.0-beta.37",
         "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
       }
     },
     "web3-shh": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.36.tgz",
-      "integrity": "sha512-bREGHS/WprYFSvGUhyIk8RSpT2Z5SvJOKGBrsUW2nDIMWO6z0Op8E7fzC6GXY2HZfZliAqq6LirbXLgcLRWuPw==",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.37.tgz",
+      "integrity": "sha512-h5STG/xqZNQWtCLYOu7NiMqwqPea8SfkKQUPUFxXKIPVCFVKpHuQEwW1qcPQRJMLhlQIv17xuoUe1A+RzDNbrw==",
       "dev": true,
       "requires": {
-        "web3-core": "1.0.0-beta.36",
-        "web3-core-method": "1.0.0-beta.36",
-        "web3-core-subscriptions": "1.0.0-beta.36",
-        "web3-net": "1.0.0-beta.36"
+        "web3-core": "1.0.0-beta.37",
+        "web3-core-method": "1.0.0-beta.37",
+        "web3-core-subscriptions": "1.0.0-beta.37",
+        "web3-net": "1.0.0-beta.37"
       }
     },
     "web3-utils": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.36.tgz",
-      "integrity": "sha512-7ri74lG5fS2Th0fhYvTtiEHMB1Pmf2p7dQx1COQ3OHNI/CHNEMjzoNMEbBU6FAENrywfoFur40K4m0AOmEUq5A==",
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.37.tgz",
+      "integrity": "sha512-kA1fyhO8nKgU21wi30oJQ/ssvu+9srMdjOTKbHYbQe4ATPcr5YNwwrxG3Bcpbu1bEwRUVKHCkqi+wTvcAWBdlQ==",
       "dev": true,
       "requires": {
         "bn.js": "4.11.6",
@@ -12164,12 +17861,6 @@
       "integrity": "sha1-2nNdmyT8yo282bN00W0qAe6VQcY=",
       "dev": true
     },
-    "xregexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
-      "integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg==",
-      "dev": true
-    },
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
@@ -12195,13 +17886,13 @@
       "dev": true
     },
     "yargs": {
-      "version": "12.0.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.2.tgz",
-      "integrity": "sha512-e7SkEx6N6SIZ5c5H22RTZae61qtn3PYUE8JYbBFlK9sYmh3DMQ6E5ygtaG/2BW0JZi4WGgTR2IV5ChqlqrDGVQ==",
+      "version": "12.0.5",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+      "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
       "dev": true,
       "requires": {
         "cliui": "^4.0.0",
-        "decamelize": "^2.0.0",
+        "decamelize": "^1.2.0",
         "find-up": "^3.0.0",
         "get-caller-file": "^1.0.1",
         "os-locale": "^3.0.0",
@@ -12211,7 +17902,7 @@
         "string-width": "^2.0.0",
         "which-module": "^2.0.0",
         "y18n": "^3.2.1 || ^4.0.0",
-        "yargs-parser": "^10.1.0"
+        "yargs-parser": "^11.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -12248,12 +17939,13 @@
       }
     },
     "yargs-parser": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-      "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+      "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
       "dev": true,
       "requires": {
-        "camelcase": "^4.1.0"
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
       }
     },
     "yargs-promise": {
@@ -12330,7 +18022,7 @@
             },
             "hash.js": {
               "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
+              "resolved": "http://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
               "integrity": "sha1-EzL/ABVsCg/92CNgE9B7d6BFFXM=",
               "dev": true,
               "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14080,7 +14080,7 @@
       }
     },
     "orbit-db-identity-provider": {
-      "version": "github:orbitdb/orbit-db-identity-provider#cb29b323ee8f1fcb8562ec0f9581dc96eae19837",
+      "version": "github:orbitdb/orbit-db-identity-provider#d099bb6f7cd2de6414768b1bf6663f9e790ad812",
       "from": "github:orbitdb/orbit-db-identity-provider#feat/resolvers",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -30,5 +30,6 @@
     "orbit-db-keystore": "github:orbitdb/orbit-db-keystore#fix/verification",
     "p-map-series": "^1.0.0",
     "web3": "~1.0.0-beta.36"
-  }
+  },
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "ipfsd-ctl": "~0.37.5",
     "mocha": "^5.2.0",
     "orbit-db": "https://github.com/orbitdb/orbit-db#orbit-db-access-controller",
-    "orbit-db-identity-provider": "github:orbitdb/orbit-db-identity-provider#feat/verify-identity",
+    "orbit-db-identity-provider": "github:orbitdb/orbit-db-identity-provider#feat/resolvers",
     "orbit-db-keystore": "github:orbitdb/orbit-db-keystore#fix/verification",
     "p-map-series": "^1.0.0",
     "web3": "~1.0.0-beta.36"

--- a/src/access-controller-interface.js
+++ b/src/access-controller-interface.js
@@ -4,23 +4,23 @@ const EventEmitter = require('events').EventEmitter
 
 /**
  * Interface for OrbitDB Access Controllers
- * 
+ *
  * Any OrbitDB access controller needs to define and implement
  * the methods defined by the interface here.
  */
 class AccessController extends EventEmitter {
-  /* 
+  /*
     Every AC needs to have a 'Factory' method
     that creates an instance of the AccessController
   */
   static async create (orbitdb, options) {}
 
   /* Return the type for this controller */
-  static get type () { 
+  static get type () {
     throw new Error(`'static get type ()' needs to be defined in the inheriting class`)
   }
 
-  /* 
+  /*
     Return the type for this controller
     NOTE! This is the only property of the interface that
     shouldn't be overridden in the inherited Access Controller
@@ -32,12 +32,12 @@ class AccessController extends EventEmitter {
   /* Each Access Controller has some address to anchor to */
   get address () {}
 
-  /* 
+  /*
     Called by the databases (the log) to see if entry should
     be allowed in the database. Return true if the entry is allowed,
-    false is not allowed 
+    false is not allowed
   */
-  async canAppend(entry, identityProvider) {}
+  async canAppend(entry) {}
 
   /* Add and remove access */
   async grant (access, identity) {}

--- a/src/contract-access-controller.js
+++ b/src/contract-access-controller.js
@@ -38,7 +38,13 @@ class ContractAccessController extends AccessController {
       console.warn(`WARNING: "${entry.identity.id}" is not a valid eth address`)
       return Promise.resolve(false)
     }
-    return await this.contract.methods.isPermitted(entry.identity.id, this.web3.utils.fromAscii('write')).call()
+    const isPermitted = await this.contract.methods.isPermitted(entry.identity.id, this.web3.utils.fromAscii('write')).call()
+    if (isPermitted) {
+      const verifiedIdentity = await identityProvider.verifyIdentity(entry.identity)
+      // Allow access if identity verifies
+      return Promise.resolve(verifiedIdentity)
+    }
+    return Promise.resolve(false)
   }
 
   async grant (capability, identifier, options = {}) {

--- a/src/contract-access-controller.js
+++ b/src/contract-access-controller.js
@@ -32,19 +32,13 @@ class ContractAccessController extends AccessController {
     }
   }
 
-  async canAppend (entry, identityProvider) {
+  async canAppend (entry) {
     // Write the custom access control logic here
     if (!isValidEthAddress(this.web3, entry.identity.id)) {
       console.warn(`WARNING: "${entry.identity.id}" is not a valid eth address`)
       return Promise.resolve(false)
     }
-    const isPermitted = await this.contract.methods.isPermitted(entry.identity.id, this.web3.utils.fromAscii('write')).call()
-    if (isPermitted) {
-      const verifiedIdentity = await identityProvider.verifyIdentity(entry.identity)
-      // Allow access if identity verifies
-      return Promise.resolve(verifiedIdentity)
-    }
-    return Promise.resolve(false)
+    return this.contract.methods.isPermitted(entry.identity.id, this.web3.utils.fromAscii('write')).call()
   }
 
   async grant (capability, identifier, options = {}) {

--- a/src/deposit-contract-access-controller.js
+++ b/src/deposit-contract-access-controller.js
@@ -33,7 +33,7 @@ class DepositContractAccessController extends AccessController {
     }
   }
 
-  async canAppend (entry, identityProvider) {
+  async canAppend (entry) {
     // Write the custom access control logic here
     if (!isValidEthAddress(this.web3, entry.identity.id)) {
       console.warn(`WARNING: "${entry.identity.id}" is not a valid eth address`)

--- a/src/ipfs-access-controller.js
+++ b/src/ipfs-access-controller.js
@@ -19,13 +19,11 @@ class IPFSAccessController extends AccessController {
     return this._write
   }
 
-  async canAppend(entry, identityProvider) {
+  async canAppend(entry) {
     // Allow if access list contain the writer's publicKey or is '*'
-    if (this.write.includes(entry.identity.publicKey) || 
+    if (this.write.includes(entry.identity.publicKey) ||
       this.write.includes('*')) {
-      const verifiedIdentity = await identityProvider.verifyIdentity(entry.identity)
-      // Allow access if identity verifies
-      return verifiedIdentity
+      return true
     }
     return false
   }

--- a/src/orbitdb-access-controller.js
+++ b/src/orbitdb-access-controller.js
@@ -23,14 +23,12 @@ class OrbitDBAccessController extends AccessController {
   }
 
   // Return true if entry is allowed to be added to the database
-  async canAppend (entry, identityProvider) {
+  async canAppend (entry) {
     // Write keys and admins keys are allowed
     const access = new Set([...this.get('write'), ...this.get('admin')])
     // If the ACL contains the writer's public key or it contains '*'
     if (access.has(entry.identity.publicKey) || access.has('*')) {
-      const verifiedIdentity = await identityProvider.verifyIdentity(entry.identity)
-      // Allow access if identity verifies
-      return verifiedIdentity
+      return true
     }
 
     return false
@@ -49,7 +47,7 @@ class OrbitDBAccessController extends AccessController {
       // and make sure all values are Sets
       Object.entries({
         ...capabilities,
-        // Add the root access controller's 'write' access list 
+        // Add the root access controller's 'write' access list
         // as admins on this controller
         ...{ admin: new Set([...(capabilities.admin || []), ...this._db.access.write])
         }

--- a/test/access-controller-handlers.test.js
+++ b/test/access-controller-handlers.test.js
@@ -47,8 +47,8 @@ Object.keys(testAPIs).forEach(API => {
       const keystore1 = Keystore.create(dbPath1 + '/keys')
       const keystore2 = Keystore.create(dbPath2 + '/keys')
 
-      id1 = await IdentityProvider.createIdentity(keystore1, 'userAA')
-      id2 = await IdentityProvider.createIdentity(keystore2, 'userBB')
+      id1 = await IdentityProvider.createIdentity({ ipfs: ipfs1, keystore1})
+      id2 = await IdentityProvider.createIdentity({ ipfs: ipfs2, keystore2})
 
       orbitdb1 = await OrbitDB.createInstance(ipfs1, {
         ACFactory: AccessControllers,

--- a/test/access-controller-handlers.test.js
+++ b/test/access-controller-handlers.test.js
@@ -47,8 +47,8 @@ Object.keys(testAPIs).forEach(API => {
       const keystore1 = Keystore.create(dbPath1 + '/keys')
       const keystore2 = Keystore.create(dbPath2 + '/keys')
 
-      id1 = await IdentityProvider.createIdentity({ ipfs: ipfs1, keystore1})
-      id2 = await IdentityProvider.createIdentity({ ipfs: ipfs2, keystore2})
+      id1 = await IdentityProvider.createIdentity({ id: 'A', keystore1})
+      id2 = await IdentityProvider.createIdentity({ id: 'B', keystore2})
 
       orbitdb1 = await OrbitDB.createInstance(ipfs1, {
         ACFactory: AccessControllers,

--- a/test/contract-access-controller-integration.test.js
+++ b/test/contract-access-controller-integration.test.js
@@ -4,6 +4,7 @@ const assert = require('assert')
 const rmrf = require('rimraf')
 const OrbitDB = require('orbit-db')
 const IdentityProvider = require('orbit-db-identity-provider')
+const EthIdentityProvider = require('orbit-db-identity-provider/src/ethereum-identity-provider')
 const Keystore = require('orbit-db-keystore')
 const AccessControllers = require('../')
 const ContractAccessController = require('../src/contract-access-controller')
@@ -58,15 +59,17 @@ Object.keys(testAPIs).forEach(API => {
 
       const keystore1 = Keystore.create(dbPath1 + '/keys')
       const keystore2 = Keystore.create(dbPath2 + '/keys')
+      //
+      // const wallet1 = await open({ privateKey: '0x3141592653589793238462643383279502884197169399375105820974944592' })
+      // const wallet2 = await open({ privateKey: '0x2141592653589793238462643383279502884197169399375105820974944592' })
 
-      const wallet1 = await open({ privateKey: '0x3141592653589793238462643383279502884197169399375105820974944592' })
-      const wallet2 = await open({ privateKey: '0x2141592653589793238462643383279502884197169399375105820974944592' })
+      const wallet1 = await EthIdentityProvider.createWallet()
+      const wallet2 = await EthIdentityProvider.createWallet()
+      IdentityProvider.addIdentityProvider(EthIdentityProvider)
 
-      const signer1 = async (id, data) => await wallet1.signMessage({ message: data })
-      const signer2 = async (id, data) => await wallet2.signMessage({ message: data })
-
-      id1 = await IdentityProvider.createIdentity(keystore1, wallet1.address, { type: 'ethers', identitySignerFn: signer1 })
-      id2 = await IdentityProvider.createIdentity(keystore2, wallet2.address, { type: 'ethers', identitySignerFn: signer2 })
+      id1 = await IdentityProvider.createIdentity({ type: 'ethereum', keystore: keystore1, wallet: wallet1 })
+      id2 = await IdentityProvider.createIdentity({ type: 'ethereum', keystore: keystore2, wallet: wallet2 })
+      console.log("ID1",id1.id, "wallet", wallet1.address)
 
       web3 = new Web3(ganache.provider())
       accounts = await web3.eth.getAccounts()
@@ -225,19 +228,19 @@ Object.keys(testAPIs).forEach(API => {
 
           it('can\'t grant access if not admin', async () => {
             await db2.access.grant('write', id2.id)
-            const canAppend = await db2.access.canAppend( { identity: id2 })
+            const canAppend = await db2.access.canAppend( { identity: id2 }, id2.provider)
             assert.equal(canAppend, false)
           })
 
           it('can\'t revoke access if not admin', async () => {
             await db2.access.revoke('write', id1.id)
-            const canAppend = await db2.access.canAppend( { identity: id1 })
+            const canAppend = await db2.access.canAppend( { identity: id1 }, id1.provider)
             assert.equal(canAppend, true)
           })
 
           it('can check permissions without defaultAccount set', async () => {
             db2.access.defaultAccount = null
-            const canAppend = await db2.access.canAppend( { identity: id1 })
+            const canAppend = await db2.access.canAppend( { identity: id1 }, id1.provider)
             assert.equal(canAppend, true)
           })
 
@@ -261,7 +264,7 @@ Object.keys(testAPIs).forEach(API => {
               err = e
             }
             assert.equal(err, null)
-            const canAppend = await db2.access.canAppend( { identity: id2 })
+            const canAppend = await db2.access.canAppend( { identity: id2 }, id2.provider)
             assert.equal(canAppend, true)
           })
 

--- a/test/contract-access-controller-integration.test.js
+++ b/test/contract-access-controller-integration.test.js
@@ -69,7 +69,6 @@ Object.keys(testAPIs).forEach(API => {
 
       id1 = await IdentityProvider.createIdentity({ type: 'ethereum', keystore: keystore1, wallet: wallet1 })
       id2 = await IdentityProvider.createIdentity({ type: 'ethereum', keystore: keystore2, wallet: wallet2 })
-      console.log("ID1",id1.id, "wallet", wallet1.address)
 
       web3 = new Web3(ganache.provider())
       accounts = await web3.eth.getAccounts()

--- a/test/contract-access-controller-integration.test.js
+++ b/test/contract-access-controller-integration.test.js
@@ -59,16 +59,11 @@ Object.keys(testAPIs).forEach(API => {
 
       const keystore1 = Keystore.create(dbPath1 + '/keys')
       const keystore2 = Keystore.create(dbPath2 + '/keys')
-      //
-      // const wallet1 = await open({ privateKey: '0x3141592653589793238462643383279502884197169399375105820974944592' })
-      // const wallet2 = await open({ privateKey: '0x2141592653589793238462643383279502884197169399375105820974944592' })
 
-      const wallet1 = await EthIdentityProvider.createWallet()
-      const wallet2 = await EthIdentityProvider.createWallet()
       IdentityProvider.addIdentityProvider(EthIdentityProvider)
 
-      id1 = await IdentityProvider.createIdentity({ type: 'ethereum', keystore: keystore1, wallet: wallet1 })
-      id2 = await IdentityProvider.createIdentity({ type: 'ethereum', keystore: keystore2, wallet: wallet2 })
+      id1 = await IdentityProvider.createIdentity({ type: 'ethereum', keystore: keystore1 })
+      id2 = await IdentityProvider.createIdentity({ type: 'ethereum', keystore: keystore2 })
 
       web3 = new Web3(ganache.provider())
       accounts = await web3.eth.getAccounts()
@@ -227,19 +222,19 @@ Object.keys(testAPIs).forEach(API => {
 
           it('can\'t grant access if not admin', async () => {
             await db2.access.grant('write', id2.id)
-            const canAppend = await db2.access.canAppend( { identity: id2 }, id2.provider)
+            const canAppend = await db2.access.canAppend({ identity: id2 })
             assert.equal(canAppend, false)
           })
 
           it('can\'t revoke access if not admin', async () => {
             await db2.access.revoke('write', id1.id)
-            const canAppend = await db2.access.canAppend( { identity: id1 }, id1.provider)
+            const canAppend = await db2.access.canAppend( { identity: id1 })
             assert.equal(canAppend, true)
           })
 
           it('can check permissions without defaultAccount set', async () => {
             db2.access.defaultAccount = null
-            const canAppend = await db2.access.canAppend( { identity: id1 }, id1.provider)
+            const canAppend = await db2.access.canAppend({ identity: id1 })
             assert.equal(canAppend, true)
           })
 
@@ -263,7 +258,7 @@ Object.keys(testAPIs).forEach(API => {
               err = e
             }
             assert.equal(err, null)
-            const canAppend = await db2.access.canAppend( { identity: id2 }, id2.provider)
+            const canAppend = await db2.access.canAppend({ identity: id2 })
             assert.equal(canAppend, true)
           })
 

--- a/test/contract-access-controller.test.js
+++ b/test/contract-access-controller.test.js
@@ -137,16 +137,16 @@ Object.keys(testAPIs).forEach(API => {
             // doesn't matter what we put here, only identity is used for the check
           }
           await accessController.grant('write', id1.id)
-          const canAppend = await accessController.canAppend(mockEntry, id1.provider)
+          const canAppend = await accessController.canAppend(mockEntry)
           assert.equal(canAppend, true)
         })
 
         it('grants access to multiple keys', async () => {
-          const canAppend1 = await accessController.canAppend({ identity: orbitdb1.identity }, orbitdb1.identity.provider)
-          const canAppend2 = await accessController.canAppend({ identity: orbitdb2.identity }, orbitdb2.identity.provider)
+          const canAppend1 = await accessController.canAppend({ identity: orbitdb1.identity })
+          const canAppend2 = await accessController.canAppend({ identity: orbitdb2.identity })
 
           await accessController.grant('write', orbitdb2.identity.id)
-          const canAppend3 = await accessController.canAppend({ identity: orbitdb2.identity }, orbitdb2.identity.provider)
+          const canAppend3 = await accessController.canAppend({ identity: orbitdb2.identity })
 
           assert.equal(canAppend1, true)
           assert.equal(canAppend2, false)
@@ -179,9 +179,9 @@ Object.keys(testAPIs).forEach(API => {
           })
 
           it('has correct capabalities', async () => {
-            const canAppend1 = await accessController.canAppend({ identity: orbitdb1.identity }, orbitdb1.identity.provider)
-            const canAppend2 = await accessController.canAppend({ identity: orbitdb2.identity }, orbitdb2.identity.provider)
-            const canAppend3 = await accessController.canAppend({ identity: { id: "someotherid"} }, orbitdb1.identity.provider)
+            const canAppend1 = await accessController.canAppend({ identity: orbitdb1.identity })
+            const canAppend2 = await accessController.canAppend({ identity: orbitdb2.identity })
+            const canAppend3 = await accessController.canAppend({ identity: { id: "someotherid"} })
 
             assert.equal(canAppend1, true)
             assert.equal(canAppend2, true)

--- a/test/contract-access-controller.test.js
+++ b/test/contract-access-controller.test.js
@@ -61,13 +61,10 @@ Object.keys(testAPIs).forEach(API => {
       const keystore1 = Keystore.create(dbPath1 + '/keys')
       const keystore2 = Keystore.create(dbPath2 + '/keys')
 
-      let wallet1 = await EthIdentityProvider.createWallet()
-      let wallet2 = await EthIdentityProvider.createWallet()
-
       IdentityProvider.addIdentityProvider(EthIdentityProvider)
 
-      id1 = await IdentityProvider.createIdentity({ type: EthIdentityProvider.type, keystore: keystore1, wallet: wallet1 })
-      id2 = await IdentityProvider.createIdentity({ type: EthIdentityProvider.type, keystore: keystore2, wallet: wallet2 })
+      id1 = await IdentityProvider.createIdentity({ type: EthIdentityProvider.type, keystore: keystore1 })
+      id2 = await IdentityProvider.createIdentity({ type: EthIdentityProvider.type, keystore: keystore2 })
 
       web3 = new Web3(ganache.provider())
       accounts = await web3.eth.getAccounts()

--- a/test/ipfs-access-controller-integration.test.js
+++ b/test/ipfs-access-controller-integration.test.js
@@ -43,16 +43,16 @@ Object.keys(testAPIs).forEach(API => {
       const keystore1 = Keystore.create(dbPath1 + '/keys')
       const keystore2 = Keystore.create(dbPath2 + '/keys')
 
-      id1 = await IdentityProvider.createIdentity(keystore1, 'userAA')
-      id2 = await IdentityProvider.createIdentity(keystore2, 'userBB')
+      id1 = await IdentityProvider.createIdentity({ ipfs: ipfs1, keystore: keystore1})
+      id2 = await IdentityProvider.createIdentity({ ipfs: ipfs2, keystore: keystore2})
 
-      orbitdb1 = await OrbitDB.createInstance(ipfs1, { 
+      orbitdb1 = await OrbitDB.createInstance(ipfs1, {
         ACFactory: AccessControllers,
         directory: dbPath1,
         identity: id1
       })
 
-      orbitdb2 = await OrbitDB.createInstance(ipfs2, { 
+      orbitdb2 = await OrbitDB.createInstance(ipfs2, {
         ACFactory: AccessControllers,
         directory: dbPath2,
         identity: id2
@@ -159,7 +159,7 @@ Object.keys(testAPIs).forEach(API => {
           }
 
           const res = await db2.iterator().collect().map(e => e.payload.value)
-          assert.equal(err, 'Error: Could not append entry, key "userBB" is not allowed to write to the log')
+          assert.equal(err, `Error: Could not append entry, key "${db2.identity.id}" is not allowed to write to the log`)
           assert.deepEqual(res.includes(e => e === 'hello!!'), false)
         })
       })

--- a/test/ipfs-access-controller-integration.test.js
+++ b/test/ipfs-access-controller-integration.test.js
@@ -43,8 +43,8 @@ Object.keys(testAPIs).forEach(API => {
       const keystore1 = Keystore.create(dbPath1 + '/keys')
       const keystore2 = Keystore.create(dbPath2 + '/keys')
 
-      id1 = await IdentityProvider.createIdentity({ ipfs: ipfs1, keystore: keystore1})
-      id2 = await IdentityProvider.createIdentity({ ipfs: ipfs2, keystore: keystore2})
+      id1 = await IdentityProvider.createIdentity({ id: 'A', keystore: keystore1})
+      id2 = await IdentityProvider.createIdentity({ id: 'B', keystore: keystore2})
 
       orbitdb1 = await OrbitDB.createInstance(ipfs1, {
         ACFactory: AccessControllers,

--- a/test/ipfs-access-controller.test.js
+++ b/test/ipfs-access-controller.test.js
@@ -112,7 +112,7 @@ Object.keys(testAPIs).forEach(API => {
           // ...
           // doesn't matter what we put here, only identity is used for the check
         }
-        const canAppend = await accessController.canAppend(mockEntry, id1.provider)
+        const canAppend = await accessController.canAppend(mockEntry)
         assert.equal(canAppend, true)
       })
     })

--- a/test/ipfs-access-controller.test.js
+++ b/test/ipfs-access-controller.test.js
@@ -44,8 +44,8 @@ Object.keys(testAPIs).forEach(API => {
       const keystore1 = Keystore.create(dbPath1 + '/keys')
       const keystore2 = Keystore.create(dbPath2 + '/keys')
 
-      id1 = await IdentityProvider.createIdentity(keystore1, 'userAA')
-      id2 = await IdentityProvider.createIdentity(keystore2, 'userBB')
+      id1 = await IdentityProvider.createIdentity({ ipfs: ipfs1, keystore: keystore1})
+      id2 = await IdentityProvider.createIdentity({ ipfs: ipfs2, keystore: keystore2})
 
       orbitdb1 = await OrbitDB.createInstance(ipfs1, {
         ACFactory: AccessControllers,

--- a/test/ipfs-access-controller.test.js
+++ b/test/ipfs-access-controller.test.js
@@ -44,8 +44,8 @@ Object.keys(testAPIs).forEach(API => {
       const keystore1 = Keystore.create(dbPath1 + '/keys')
       const keystore2 = Keystore.create(dbPath2 + '/keys')
 
-      id1 = await IdentityProvider.createIdentity({ ipfs: ipfs1, keystore: keystore1})
-      id2 = await IdentityProvider.createIdentity({ ipfs: ipfs2, keystore: keystore2})
+      id1 = await IdentityProvider.createIdentity({ id: 'A', keystore: keystore1})
+      id2 = await IdentityProvider.createIdentity({ id: 'B', keystore: keystore2})
 
       orbitdb1 = await OrbitDB.createInstance(ipfs1, {
         ACFactory: AccessControllers,

--- a/test/orbit-db-access-controller-integration.test.js
+++ b/test/orbit-db-access-controller-integration.test.js
@@ -42,8 +42,8 @@ Object.keys(testAPIs).forEach(API => {
       const keystore1 = Keystore.create(dbPath1 + '/keys')
       const keystore2 = Keystore.create(dbPath2 + '/keys')
 
-      id1 = await IdentityProvider.createIdentity(keystore1, 'userAA')
-      id2 = await IdentityProvider.createIdentity(keystore2, 'userBB')
+      id1 = await IdentityProvider.createIdentity({ ipfs: ipfs1, keystore: keystore1})
+      id2 = await IdentityProvider.createIdentity({ ipfs: ipfs2, keystore: keystore2})
 
       orbitdb1 = await OrbitDB.createInstance(ipfs1, {
         ACFactory: AccessControllers,
@@ -155,7 +155,7 @@ Object.keys(testAPIs).forEach(API => {
             err = e
           }
 
-          assert.equal(err, 'Error: Could not append entry, key "userBB" is not allowed to write to the log')
+          assert.equal(err, `Error: Could not append entry, key "${db2.identity.id}" is not allowed to write to the log`)
 
           const doChanges = () => {
             return new Promise(async (resolve, reject) => {
@@ -191,7 +191,7 @@ Object.keys(testAPIs).forEach(API => {
           } catch (e) {
             err = e
           }
-          assert.equal(err, 'Error: Could not append entry, key "userBB" is not allowed to write to the log')
+          assert.equal(err, `Error: Could not append entry, key "${db2.identity.id}" is not allowed to write to the log`)
         })
 
         it('can\'t revoke access if doesn\'t have write access', async () => {
@@ -201,7 +201,7 @@ Object.keys(testAPIs).forEach(API => {
           } catch (e) {
             err = e
           }
-          assert.equal(err, 'Error: Could not append entry, key "userBB" is not allowed to write to the log')
+          assert.equal(err, `Error: Could not append entry, key "${db2.identity.id}" is not allowed to write to the log`)
         })
 
         it('revoking access disables ability to write to the database', async () => {
@@ -227,7 +227,7 @@ Object.keys(testAPIs).forEach(API => {
             })
           }
           const err = await getError()
-          assert.equal(err, 'Error: Could not append entry, key "userBB" is not allowed to write to the log')
+          assert.equal(err, `Error: Could not append entry, key "${db2.identity.id}" is not allowed to write to the log`)
         })
       })
     })

--- a/test/orbit-db-access-controller-integration.test.js
+++ b/test/orbit-db-access-controller-integration.test.js
@@ -42,8 +42,8 @@ Object.keys(testAPIs).forEach(API => {
       const keystore1 = Keystore.create(dbPath1 + '/keys')
       const keystore2 = Keystore.create(dbPath2 + '/keys')
 
-      id1 = await IdentityProvider.createIdentity({ ipfs: ipfs1, keystore: keystore1})
-      id2 = await IdentityProvider.createIdentity({ ipfs: ipfs2, keystore: keystore2})
+      id1 = await IdentityProvider.createIdentity({ id: 'A', keystore: keystore1})
+      id2 = await IdentityProvider.createIdentity({ id: 'B', keystore: keystore2})
 
       orbitdb1 = await OrbitDB.createInstance(ipfs1, {
         ACFactory: AccessControllers,

--- a/test/orbit-db-access-controller.test.js
+++ b/test/orbit-db-access-controller.test.js
@@ -43,8 +43,8 @@ Object.keys(testAPIs).forEach(API => {
       const keystore1 = Keystore.create(dbPath1 + '/keys')
       const keystore2 = Keystore.create(dbPath2 + '/keys')
 
-      id1 = await IdentityProvider.createIdentity(keystore1, 'userAA')
-      id2 = await IdentityProvider.createIdentity(keystore2, 'userBB')
+      id1 = await IdentityProvider.createIdentity({ipfs: ipfs1, keystore: keystore1 })
+      id2 = await IdentityProvider.createIdentity({ipfs: ipfs2, keystore: keystore2 })
 
       orbitdb1 = await OrbitDB.createInstance(ipfs1, {
         ACFactory: AccessControllers,

--- a/test/orbit-db-access-controller.test.js
+++ b/test/orbit-db-access-controller.test.js
@@ -43,8 +43,8 @@ Object.keys(testAPIs).forEach(API => {
       const keystore1 = Keystore.create(dbPath1 + '/keys')
       const keystore2 = Keystore.create(dbPath2 + '/keys')
 
-      id1 = await IdentityProvider.createIdentity({ipfs: ipfs1, keystore: keystore1 })
-      id2 = await IdentityProvider.createIdentity({ipfs: ipfs2, keystore: keystore2 })
+      id1 = await IdentityProvider.createIdentity({id: 'A', keystore: keystore1 })
+      id2 = await IdentityProvider.createIdentity({id: 'B', keystore: keystore2 })
 
       orbitdb1 = await OrbitDB.createInstance(ipfs1, {
         ACFactory: AccessControllers,

--- a/test/orbit-db-access-controller.test.js
+++ b/test/orbit-db-access-controller.test.js
@@ -116,7 +116,7 @@ Object.keys(testAPIs).forEach(API => {
           // ...
           // doesn't matter what we put here, only identity is used for the check
         }
-        const canAppend = await accessController.canAppend(mockEntry, id1.provider)
+        const canAppend = await accessController.canAppend(mockEntry)
         assert.equal(canAppend, true)
       })
     })
@@ -193,8 +193,8 @@ Object.keys(testAPIs).forEach(API => {
         const mockEntry2 = {
           identity: id2,
         }
-        const canAppend1 = await accessController.canAppend(mockEntry1, id1.provider)
-        const canAppend2 = await accessController.canAppend(mockEntry2, id2.provider)
+        const canAppend1 = await accessController.canAppend(mockEntry1)
+        const canAppend2 = await accessController.canAppend(mockEntry2)
         assert.equal(canAppend1, true)
         assert.equal(canAppend2, true)
       })
@@ -275,8 +275,8 @@ Object.keys(testAPIs).forEach(API => {
         const mockEntry2 = {
           identity: id2
         }
-        const canAppend = await accessController.canAppend(mockEntry1, id1.provider)
-        const noAppend = await accessController.canAppend(mockEntry2, id2.provider)
+        const canAppend = await accessController.canAppend(mockEntry1)
+        const noAppend = await accessController.canAppend(mockEntry2)
         assert.equal(canAppend, true)
         assert.equal(noAppend, false)
       })


### PR DESCRIPTION
This PR uses the latest identity-provider for identity-creation and removes idenitty-provider from canAppend

depends on identity-provider [pull/13](https://github.com/orbitdb/orbit-db-identity-provider/pull/13)