### PR TITLE
feat: Allow creation of legacy ipfs-access-controller instances

### DIFF
--- a/src/access-controllers.js
+++ b/src/access-controllers.js
@@ -61,6 +61,9 @@ class AccessControllers {
     const AccessController = getHandlerFor(type)
     const ac = await AccessController.create(orbitdb, options)
     const params = await ac.save()
+    if (options.legacy) {
+      return params.address
+    }
     const hash = await AccessControllerManifest.create(orbitdb._ipfs, type, params)
     return hash
   }

--- a/src/ipfs-access-controller.js
+++ b/src/ipfs-access-controller.js
@@ -8,6 +8,7 @@ class IPFSAccessController extends AccessController {
     super()
     this._ipfs = ipfs
     this._write = Array.from(options.write || [])
+    this._legacy = options.legacy
   }
 
   // Returns the type of the access controller
@@ -42,9 +43,18 @@ class IPFSAccessController extends AccessController {
 
   async save () {
     let cid
+    let access
+    let codec
+    if (!this._legacy) {
+      access = { write: JSON.stringify(this.write, null, 2) }
+      codec = 'dag-cbor'
+    } else {
+      access = { admin: [], write: this.write, read: [] }
+      codec = 'dag-pb'
+    }
     try {
 
-      cid = await io.write(this._ipfs, 'dag-cbor', { write: JSON.stringify(this.write, null, 2) })
+      cid = await io.write(this._ipfs, codec, access, { legacy: this._legacy })
 
     } catch (e) {
       console.log('IPFSAccessController.save ERROR:', e)


### PR DESCRIPTION
This PR enables the creation of the legacy ipfs-access-controller, for backwards compatibility reasons. The old controller did not have any manifest, so this code simply returns the hash of the access controller directly.

To use the legacy access controller pass the following when creating a DB:
```
const options = {
  accessController: {
    legacy: true,
    write: [ ... ]
  }
}
```

This PR Depends on https://github.com/orbitdb/orbit-db-io/pull/2