### PR TITLE
Permissions based on identity and new identity providers 

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ipfs-repo": "^0.26.1",
     "ipfsd-ctl": "^0.40.3",
     "mocha": "^5.2.0",
-    "orbit-db": "next",
+    "orbit-db": "0.20.0",
     "orbit-db-identity-provider": "~0.1.0",
     "orbit-db-keystore": "~0.2.0",
     "standard": "^12.0.1",

--- a/src/ipfs-access-controller.js
+++ b/src/ipfs-access-controller.js
@@ -20,13 +20,13 @@ class IPFSAccessController extends AccessController {
 
   async canAppend (entry, identityProvider) {
     // Allow if access list contain the writer's publicKey or is '*'
-    const publicKey = entry.v === 0 ? entry.key : entry.identity.publicKey
-    if (this.write.includes(publicKey) ||
-      this.write.includes('*')) {
-      return true
+    const publicKey = entry.v === 0 ? entry.key : entry.identity.id
+    if (this.write.includes(publicKey) || this.write.includes('*')) {
+      return entry.v === 1 ? await identityProvider.verifyIdentity(entry.identity) : true
     }
     return false
   }
+
 
   async load (address) {
     // Transform '/ipfs/QmPFtHi3cmfZerxtH9ySLdzpg1yFhocYDZgEZywdUXHxFU'

--- a/src/orbitdb-access-controller.js
+++ b/src/orbitdb-access-controller.js
@@ -27,7 +27,7 @@ class OrbitDBAccessController extends AccessController {
     // Write keys and admins keys are allowed
     const access = new Set([...this.get('write'), ...this.get('admin')])
     // If the ACL contains the writer's public key or it contains '*'
-    if (access.has(entry.identity.publicKey) || access.has('*')) {
+    if (access.has(entry.identity.id) || access.has('*')) {
       const verifiedIdentity = await identityProvider.verifyIdentity(entry.identity)
       // Allow access if identity verifies
       return verifiedIdentity
@@ -76,7 +76,7 @@ class OrbitDBAccessController extends AccessController {
       // use ipfs controller as a immutable "root controller"
       accessController: {
         type: 'ipfs',
-        write: this._options.admin || [this._orbitdb.identity.publicKey]
+        write: this._options.admin || [this._orbitdb.identity.id]
       },
       sync: true
     })


### PR DESCRIPTION
May be misunderstanding new identity providers, but it seem like the permissions, specifically write permission in this example should be based on the identity id and then use the identity provider to verify. Orbitdb keys are provisioned upon use and in different systems identities may be used across differing contexts (or have revocation, rotations, etc) where there will be different local orbitdb keys for signing (for same id). So seems like permissions would be based on identity id not the orbitdb pubkey. ( i saw the orbit identity provider where these are one and the same). And why verify identity in orbitdb AC if not using that identity for access control. 

This code was just for context and explanation, not tested yet. Two changes, one, used identity.id for permissions, and then in ipfs access controller if using identity.id, also verify identity. 

If the explanation above was intended functionality I can finish creating and testing this PR.