### PR TITLE
fix: use path.posix

### DIFF
--- a/src/utils/ensure-ac-address.js
+++ b/src/utils/ensure-ac-address.js
@@ -5,6 +5,6 @@ const ensureAddress = address => {
   const suffix = address.toString().split('/').pop()
   return suffix === '_access'
     ? address
-    : path.join(address, '/_access')
+    : (path.posix || path).join(address, '/_access')
 }
 module.exports = ensureAddress


### PR DESCRIPTION
* Fixes issue regarding path on windows when using `orbitdb` access controller, or access controllers that use `ensure-ac-address.js`

Let me know if I am missing anything, comments etc. 