### PR TITLE
Add hasCapability method to check if an identity has a capability

### DIFF
--- a/src/orbitdb-access-controller.js
+++ b/src/orbitdb-access-controller.js
@@ -93,7 +93,13 @@ class OrbitDBAccessController extends AccessController {
       address: this._db.address.toString()
     }
   }
-
+  
+  async hasCapability (capability, identity) {
+    // Write keys and admins keys are allowed
+    const access = new Set(this.get(capability))
+    return access.has(identity.id) || access.has("*")
+  }
+  
   async grant (capability, key) {
     // Merge current keys with the new key
     const capabilities = new Set([...(this._db.get(capability) || []), ...[key]])


### PR DESCRIPTION
This PR squashes [this](https://github.com/orbitdb/orbit-db-access-controllers/pull/66) and adds a `hasCapability` method, which checks if an identity has a given capability. 